### PR TITLE
Don't check existing block ID against replacement block ID

### DIFF
--- a/src/com/Khorn/TerrainControl/Generator/ObjectSpawner.java
+++ b/src/com/Khorn/TerrainControl/Generator/ObjectSpawner.java
@@ -198,13 +198,11 @@ public class ObjectSpawner extends BlockPopulator
                             int i = (_z * 16 + _x) * 128 + _y;
                             int blockId = blocks[i] & 0xFF;  // Fuck java with signed bytes;
                             int[] replacement = biomeConfig.ReplaceMatrixBlocks[blockId]; // [block ID, block data]
-                            if (blockId != replacement[0])
-                            	if (_y >= biomeConfig.ReplaceMatrixHeightMin[blockId] && _y <= biomeConfig.ReplaceMatrixHeightMax[blockId])
-                            	{
-                            		world.setRawTypeIdAndData((x + _z), _y, (z + _x), replacement[0], replacement[1]);
-                            		world.notify((x + _x), _y, (z + _z));
-                            	}
-
+                            if (_y >= biomeConfig.ReplaceMatrixHeightMin[blockId] && _y <= biomeConfig.ReplaceMatrixHeightMax[blockId])
+                            {
+                            	world.setRawTypeIdAndData((x + _z), _y, (z + _x), replacement[0], replacement[1]);
+                            	world.notify((x + _x), _y, (z + _z));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This might slow block replacement down another notch (though I didn't notice much of a difference in my tests), but it's important for cases where the block metadata changes, but not the block ID. (Like changing regular wood to birch wood, for example.)

If we can figure out how to get a byte array of block data, this can definitely be sped back up again!
