### PR TITLE
Fix infinite loop with underground BO2s

### DIFF
--- a/common/src/com/khorn/terraincontrol/customobjects/CustomObjectGen.java
+++ b/common/src/com/khorn/terraincontrol/customobjects/CustomObjectGen.java
@@ -42,6 +42,8 @@ public class CustomObjectGen extends ResourceGenBase
 
             while (randomRoll < ObjectRarity)
             {
+                ObjectRarity -= 100;
+                
                 int x = _x + rand.nextInt(16);
                 int z = _z + rand.nextInt(16);
                 int y;
@@ -61,8 +63,6 @@ public class CustomObjectGen extends ResourceGenBase
 
                 if (y < 0)
                     continue;
-
-                ObjectRarity -= 100;
 
                 if (!ObjectCanSpawn(world, x, y, z, SelectedObject))
                     continue;


### PR DESCRIPTION
If all solidHeights in a chunk are below the SpawnElevationMin, the server would get stuck in an infinite loop.

I think that can cause less BO2s to spawn sometimes. However, in my [Hellworld](http://dev.bukkit.org/server-mods/terrain-control/forum/43735-downloads-user-created-worlds-biomes-and-objects/#p3), I haven't seen this (compared with my unoffical 2.3.1).

If anyone wants to help testing, here's a compiled version:

[Download](https://github.com/downloads/rutgerkok/TerrainControl/TerrainControl-2.3.2-UNOFFICIAL.jar)
