### PR TITLE
Added blocks and rotations

### DIFF
--- a/common/src/com/khorn/terraincontrol/DefaultMaterial.java
+++ b/common/src/com/khorn/terraincontrol/DefaultMaterial.java
@@ -143,6 +143,15 @@ public enum DefaultMaterial
     SPRUCE_WOOD_STAIRS(134),
     BIRCH_WOOD_STAIRS(135),
     JUNGLE_WOOD_STAIRS(136),
+    COMMAND(137),
+    BEACON(138),
+    COBBLE_WALL(139, false),
+    FLOWER_POT(140, false),
+    CARROT(141, false),
+    POTATO(142, false),
+    WOOD_BUTTON(143, false),
+    SKULL(144, false),
+    ANVIL(145, false),
     UNKNOWN_BLOCK(255);
 
     public final int id;

--- a/common/src/com/khorn/terraincontrol/util/BlockHelper.java
+++ b/common/src/com/khorn/terraincontrol/util/BlockHelper.java
@@ -45,7 +45,15 @@ public class BlockHelper
                     case 3: return 5 | power;
                 }
                 break;
-
+                
+            case LOG:
+                switch(data / 4) {
+                    case 1: return data + 4; // East/West-->North/South horizontal log
+                    case 2: return data - 4; // North/South-->East/West horizontal log
+                    // Default: vertical or all-bark log
+                }
+                break;
+                
             case WOOD_STAIRS:
             case COBBLESTONE_STAIRS:
             case BRICK_STAIRS:
@@ -65,6 +73,7 @@ public class BlockHelper
 
             case LEVER:
             case STONE_BUTTON:
+            case WOOD_BUTTON:
                 int thrown = data & 0x8;
                 int withoutThrown = data & ~0x8;
                 switch (withoutThrown) {
@@ -94,6 +103,7 @@ public class BlockHelper
             case LADDER:
             case WALL_SIGN:
             case CHEST:
+            case ENDER_CHEST:
             case FURNACE:
             case BURNING_FURNACE:
             case DISPENSER:
@@ -159,6 +169,23 @@ public class BlockHelper
 
             case FENCE_GATE:
                 return ((data + 3) & 0x3) | (data & ~0x3);
+                
+            case COCOA:
+                int rotationData = data % 4;
+                if(rotationData == 0) {
+                    return data + 3;
+                } else {
+                    return data - 1; 
+                }
+           
+            case ANVIL:
+                if(data % 2 == 0) {
+                    // North-south --> west-east
+                    return data + 1;
+                } else {
+                    // West-east --> north-south
+                    return data - 1;
+                }
         }
 
         return data;


### PR DESCRIPTION
_(I keep spamming you with pull requests... If you would rather work on Terrain Control yourself without me constantly stepping on your toes, just say so.)_
- All blocks of 1.4 have been added.
- Logs, wooden buttons, Ender Chests, cocoa plants and anvils used in BO2s can now be
  rotated.

[Some BO2s to test](https://dl.dropbox.com/u/23288978/terraincontrol/RotationTestBO2s.zip)

[Compiled Terrain Control](https://github.com/downloads/rutgerkok/TerrainControl/TerrainControl-2.3.2-UNOFFICIAL2.jar)
