### PR TITLE
Updated event system to support Minecraft Forge terrain events.

### DIFF
--- a/common/src/com/khorn/terraincontrol/EventHandler.java
+++ b/common/src/com/khorn/terraincontrol/EventHandler.java
@@ -2,43 +2,10 @@ package com.khorn.terraincontrol;
 
 import com.khorn.terraincontrol.customobjects.CustomObject;
 
-/**
- * Inherit this class, override methods as necessary and register it with
- * TerrainControl.registerEventHander(..). If you want to use the onStart(),
- * make sure that it is registered before TerrainControl is started.
- * 
+/*
+ * Use com.khorn.terraincontrol.events.EventHandler instead
  */
-public abstract class EventHandler
+@Deprecated
+public abstract class EventHandler extends com.khorn.terraincontrol.events.EventHandler
 {
-    /**
-     * Called when it's time to register the custom resources and objects.
-     */
-    public void onStart()
-    {
-
-    }
-
-    /**
-     * Called whenever a custom object successfully spawns.
-     * 
-     * It is up to the implementation of the CustomObject to fire this
-     * event. UseWorld and UseBiome won't fire this event, but BO2 and BO3 will.
-     * 
-     * This event should NOT be used to modify data in the object or the world.
-     * 
-     * @param object
-     *            The object that is about to spawn.
-     * @param world
-     *            The world where it will spawn.
-     * @param x
-     *            The x of the object origin.
-     * @param y
-     *            The y of the object origin.
-     * @param z
-     *            The z of the object origin.
-     */
-    public void onCustomObjectSpawn(CustomObject object, LocalWorld world, int x, int y, int z)
-    {
-
-    }
 }

--- a/common/src/com/khorn/terraincontrol/TerrainControl.java
+++ b/common/src/com/khorn/terraincontrol/TerrainControl.java
@@ -8,6 +8,10 @@ import com.khorn.terraincontrol.configuration.ConfigFunctionsManager;
 import com.khorn.terraincontrol.customobjects.CustomObject;
 import com.khorn.terraincontrol.customobjects.CustomObjectLoader;
 import com.khorn.terraincontrol.customobjects.CustomObjectManager;
+import com.khorn.terraincontrol.events.CustomObjectSpawnEvent;
+import com.khorn.terraincontrol.events.EventHandler;
+import com.khorn.terraincontrol.events.PopulateEvent;
+import com.khorn.terraincontrol.events.ResourceEvent;
 
 public class TerrainControl
 {
@@ -189,12 +193,35 @@ public class TerrainControl
     {
         eventHandlers.add(handler);
     }
-    
+
+    @Deprecated
     public static void fireCustomObjectSpawnEvent(CustomObject object, LocalWorld world, int x, int y, int z)
+    {
+    	CustomObjectSpawnEvent event = new CustomObjectSpawnEvent(object, world, x, y, z);
+    	fireCustomObjectSpawnEvent(event);
+    }
+
+    public static void fireCustomObjectSpawnEvent(CustomObjectSpawnEvent event)
     {
         for(EventHandler handler: eventHandlers)
         {
-            handler.onCustomObjectSpawn(object, world, x, y, z);
+            handler.onCustomObjectSpawn(event);
         }
     }
+
+	public static void firePopulateEvent(PopulateEvent event)
+	{    	
+        for(EventHandler handler: eventHandlers)
+        {
+            handler.onPopulateEvent(event);
+        }
+	}
+
+	public static void fireResourceEvent(ResourceEvent event)
+	{    	
+        for(EventHandler handler: eventHandlers)
+        {
+            handler.onResourceEvent(event);
+        }
+	}
 }

--- a/common/src/com/khorn/terraincontrol/events/ChunkEvent.java
+++ b/common/src/com/khorn/terraincontrol/events/ChunkEvent.java
@@ -1,0 +1,52 @@
+package com.khorn.terraincontrol.events;
+
+import java.util.Random;
+
+import com.khorn.terraincontrol.LocalWorld;
+import com.khorn.terraincontrol.events.PopulateEvent.Type;
+
+public abstract class ChunkEvent
+{
+	private final LocalWorld world;
+	private final Random random;
+	private final int x;
+	private final int z;
+	private final boolean hasGeneratedAVillage;
+	
+	/**
+     * @param world
+     *            The world populated.
+     * @param chunkX
+     *            The x (chunk) of the populated chunk.
+     * @param chunkZ
+     *            The z (chunk) of the populated chunk.
+	 */
+	public ChunkEvent(LocalWorld world, Random random, int chunkX, int chunkZ, boolean hasGeneratedAVillage)
+	{
+		this.world = world;
+		this.random = random;
+		this.x = chunkX;
+		this.z = chunkZ;
+		this.hasGeneratedAVillage = hasGeneratedAVillage;
+	}
+
+	public LocalWorld getWorld() {
+		return world;
+	}
+
+	public Random getRandom() {
+		return random;
+	}
+
+	public int getChunkX() {
+		return x;
+	}
+
+	public int getChunkZ() {
+		return z;
+	}
+
+	public boolean hasGeneratedAVillage() {
+		return hasGeneratedAVillage;
+	}
+}

--- a/common/src/com/khorn/terraincontrol/events/CustomObjectSpawnEvent.java
+++ b/common/src/com/khorn/terraincontrol/events/CustomObjectSpawnEvent.java
@@ -1,0 +1,61 @@
+package com.khorn.terraincontrol.events;
+
+import com.khorn.terraincontrol.LocalWorld;
+import com.khorn.terraincontrol.customobjects.CustomObject;
+
+public class CustomObjectSpawnEvent
+{
+	private final CustomObject object;
+	private final LocalWorld world;
+	private final int x;
+	private final int y;
+	private final int z;
+	
+	/**
+     * This event should NOT be used to modify data in the object or the world.
+     * 
+     * @param object
+     *            The object that is about to spawn.
+     * @param world
+     *            The world where it will spawn.
+     * @param x
+     *            The x of the object origin.
+     * @param y
+     *            The y of the object origin.
+     * @param z
+     *            The z of the object origin.
+	 */
+	public CustomObjectSpawnEvent(CustomObject object, LocalWorld world, int x, int y, int z)
+	{
+		this.object = object;
+		this.world = world;
+		this.x = x;
+		this.y = y;
+		this.z = z;
+	}
+
+	public CustomObject getObject()
+	{
+		return object;
+	}
+
+	public LocalWorld getWorld()
+	{
+		return world;
+	}
+
+	public int getX()
+	{
+		return x;
+	}
+
+	public int getY()
+	{
+		return y;
+	}
+
+	public int getZ()
+	{
+		return z;
+	}
+}

--- a/common/src/com/khorn/terraincontrol/events/EventHandler.java
+++ b/common/src/com/khorn/terraincontrol/events/EventHandler.java
@@ -1,0 +1,46 @@
+package com.khorn.terraincontrol.events;
+
+
+/**
+ * Inherit this class, override methods as necessary and register it with
+ * TerrainControl.registerEventHander(..). If you want to use the onStart(),
+ * make sure that it is registered before TerrainControl is started.
+ * 
+ */
+public abstract class EventHandler
+{
+    /**
+     * Called when it's time to register the custom resources and objects.
+     */
+    public void onStart()
+    {
+
+    }
+
+    /**
+     * Called whenever a custom object successfully spawns.
+     * 
+     * It is up to the implementation of the CustomObject to fire this
+     * event. UseWorld and UseBiome won't fire this event, but BO2 and BO3 will.
+     */
+    public void onCustomObjectSpawn(CustomObjectSpawnEvent event)
+    {
+
+    }
+
+    /**
+     * Called at the beginning and end of chunk population.
+     */
+	public void onPopulateEvent(PopulateEvent event)
+	{
+
+	}
+
+    /**
+     * Called before spawning a resource. Cancelling the event cancels the spawn.
+     */
+	public void onResourceEvent(ResourceEvent event)
+	{
+
+	}
+}

--- a/common/src/com/khorn/terraincontrol/events/PopulateEvent.java
+++ b/common/src/com/khorn/terraincontrol/events/PopulateEvent.java
@@ -1,0 +1,27 @@
+package com.khorn.terraincontrol.events;
+
+import java.util.Random;
+
+import com.khorn.terraincontrol.LocalWorld;
+
+public class PopulateEvent extends ChunkEvent
+{
+	public enum Type
+	{
+		BEGIN,
+		END
+	}
+	
+	private final Type type;
+	
+	public PopulateEvent(Type type, LocalWorld world, Random random, int chunkX, int chunkZ, boolean hasGeneratedAVillage)
+	{
+		super(world, random, chunkX, chunkZ, hasGeneratedAVillage);
+		this.type = type;
+	}
+
+	public Type getType()
+	{
+		return type;
+	}
+}

--- a/common/src/com/khorn/terraincontrol/events/ResourceEvent.java
+++ b/common/src/com/khorn/terraincontrol/events/ResourceEvent.java
@@ -1,0 +1,65 @@
+package com.khorn.terraincontrol.events;
+
+import java.util.Random;
+
+import com.khorn.terraincontrol.LocalWorld;
+
+public class ResourceEvent extends ChunkEvent
+{
+	public enum Type
+	{
+		ABOVE_WATER,
+		CACTUS,
+		CUSTOM_OBJECT,
+		DUNGEON,
+		GRASS,
+		ICE,
+		LIQUID,
+		ORE,
+		PLANT,
+		REED,
+		SMALL_LAKE,
+		TREE,
+		UNDERGROUND_LAKE,
+		UNDERWATER_ORE,
+		VINES
+	}
+	
+	private final Type type;
+	private final int blockId;
+	private final int blockData;
+	private boolean cancel = false;
+	
+	public ResourceEvent(Type type, LocalWorld world, Random random, int chunkX, int chunkZ, int blockId, int blockData, boolean hasGeneratedAVillage)
+	{
+		super(world, random, chunkX, chunkZ, hasGeneratedAVillage);
+		this.type = type;
+		this.blockId = blockId;
+		this.blockData = blockData;
+	}
+
+	public boolean isCancelled()
+	{
+		return cancel;
+	}
+
+	public void cancel()
+	{
+		this.cancel = true;
+	}
+
+	public Type getType()
+	{
+		return type;
+	}
+
+	public int getBlockId()
+	{
+		return blockId;
+	}
+
+	public int getBlockData()
+	{
+		return blockData;
+	}
+}

--- a/common/src/com/khorn/terraincontrol/generator/ObjectSpawner.java
+++ b/common/src/com/khorn/terraincontrol/generator/ObjectSpawner.java
@@ -1,14 +1,20 @@
 package com.khorn.terraincontrol.generator;
 
+import static com.khorn.terraincontrol.events.PopulateEvent.Type.BEGIN;
+import static com.khorn.terraincontrol.events.PopulateEvent.Type.END;
+import static com.khorn.terraincontrol.events.ResourceEvent.Type.ICE;
+
 import java.util.Random;
 
 import com.khorn.terraincontrol.DefaultMaterial;
 import com.khorn.terraincontrol.LocalWorld;
+import com.khorn.terraincontrol.TerrainControl;
 import com.khorn.terraincontrol.configuration.BiomeConfig;
 import com.khorn.terraincontrol.configuration.TCDefaultValues;
 import com.khorn.terraincontrol.configuration.WorldConfig;
+import com.khorn.terraincontrol.events.PopulateEvent;
+import com.khorn.terraincontrol.events.ResourceEvent;
 import com.khorn.terraincontrol.generator.resourcegens.Resource;
-import com.khorn.terraincontrol.generator.resourcegens.SmallLakeGen;
 
 public class ObjectSpawner
 {
@@ -36,25 +42,30 @@ public class ObjectSpawner
         long l2 = this.rand.nextLong() / 2L * 2L + 1L;
         this.rand.setSeed(chunkX * l1 + chunkZ * l2 ^ world.getSeed());
 
+        TerrainControl.firePopulateEvent(new PopulateEvent(BEGIN, world, rand, chunkX, chunkZ, false));
+        
         boolean hasGeneratedAVillage = world.PlaceTerrainObjects(rand, chunkX, chunkZ);
 
         // Resource sequence
         for (int i = 0; i < localBiomeConfig.ResourceCount; i++)
         {
-            Resource res = localBiomeConfig.ResourceSequence[i];
-            if (res instanceof SmallLakeGen && hasGeneratedAVillage)
-                continue;
             world.setChunksCreations(false);
-            res.process(world, rand, chunkX, chunkZ);
+            Resource res = localBiomeConfig.ResourceSequence[i];
+            res.process(world, rand, chunkX, chunkZ, hasGeneratedAVillage);
         }
 
         // Snow and ice
-        placeSnowAndIce(chunkX, chunkZ);
+        ResourceEvent event = new ResourceEvent(ICE, world, rand, chunkX, chunkZ, DefaultMaterial.ICE.id, 0, hasGeneratedAVillage);
+        TerrainControl.fireResourceEvent(event);
+        if (!event.isCancelled())
+        	placeSnowAndIce(chunkX, chunkZ);
 
         world.replaceBlocks();
 
         world.replaceBiomesLate();
 
+        TerrainControl.firePopulateEvent(new PopulateEvent(END, world, rand, chunkX, chunkZ, hasGeneratedAVillage));
+        
         if (this.worldSettings.isDeprecated)
             this.worldSettings = this.worldSettings.newSettings;
     }

--- a/common/src/com/khorn/terraincontrol/generator/resourcegens/AboveWaterGen.java
+++ b/common/src/com/khorn/terraincontrol/generator/resourcegens/AboveWaterGen.java
@@ -1,10 +1,13 @@
 package com.khorn.terraincontrol.generator.resourcegens;
 
-import com.khorn.terraincontrol.LocalWorld;
-import com.khorn.terraincontrol.exception.InvalidResourceException;
+import static com.khorn.terraincontrol.events.ResourceEvent.Type.ABOVE_WATER;
 
 import java.util.List;
 import java.util.Random;
+
+import com.khorn.terraincontrol.LocalWorld;
+import com.khorn.terraincontrol.events.ResourceEvent;
+import com.khorn.terraincontrol.exception.InvalidResourceException;
 
 public class AboveWaterGen extends Resource
 {
@@ -49,4 +52,9 @@ public class AboveWaterGen extends Resource
         return "AboveWaterRes(" + makeMaterial(blockId) + "," + frequency + "," + rarity + ")";
     }
 
+	@Override
+	protected ResourceEvent getResourceEvent(LocalWorld world, Random random,
+			int chunkX, int chunkZ, boolean hasGeneratedAVillage) {
+		return new ResourceEvent(ABOVE_WATER, world, random, chunkX, chunkZ, blockId, blockData, hasGeneratedAVillage);
+	}
 }

--- a/common/src/com/khorn/terraincontrol/generator/resourcegens/CactusGen.java
+++ b/common/src/com/khorn/terraincontrol/generator/resourcegens/CactusGen.java
@@ -1,11 +1,14 @@
 package com.khorn.terraincontrol.generator.resourcegens;
 
+import static com.khorn.terraincontrol.events.ResourceEvent.Type.CACTUS;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
 import com.khorn.terraincontrol.LocalWorld;
 import com.khorn.terraincontrol.TerrainControl;
+import com.khorn.terraincontrol.events.ResourceEvent;
 import com.khorn.terraincontrol.exception.InvalidResourceException;
 
 public class CactusGen extends Resource
@@ -67,4 +70,10 @@ public class CactusGen extends Resource
             sourceBlocks.add(getBlockId(args.get(i)));
         }
     }
+
+	@Override
+	protected ResourceEvent getResourceEvent(LocalWorld world, Random random,
+			int chunkX, int chunkZ, boolean hasGeneratedAVillage) {
+		return new ResourceEvent(CACTUS, world, random, chunkX, chunkZ, blockId, blockData, hasGeneratedAVillage);
+	}
 }

--- a/common/src/com/khorn/terraincontrol/generator/resourcegens/CustomObjectGen.java
+++ b/common/src/com/khorn/terraincontrol/generator/resourcegens/CustomObjectGen.java
@@ -1,5 +1,7 @@
 package com.khorn.terraincontrol.generator.resourcegens;
 
+import static com.khorn.terraincontrol.events.ResourceEvent.Type.CUSTOM_OBJECT;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -7,6 +9,7 @@ import java.util.Random;
 import com.khorn.terraincontrol.LocalWorld;
 import com.khorn.terraincontrol.TerrainControl;
 import com.khorn.terraincontrol.customobjects.CustomObject;
+import com.khorn.terraincontrol.events.ResourceEvent;
 import com.khorn.terraincontrol.exception.InvalidResourceException;
 import com.khorn.terraincontrol.util.Txt;
 
@@ -44,8 +47,13 @@ public class CustomObjectGen extends Resource
     }
 
     @Override
-    public void process(LocalWorld world, Random random, int chunkX, int chunkZ)
+    public void process(LocalWorld world, Random random, int chunkX, int chunkZ, boolean hasGeneratedAVillage)
     {
+        ResourceEvent event = getResourceEvent(world, random, chunkX, chunkZ, hasGeneratedAVillage);
+        TerrainControl.fireResourceEvent(event);
+        if (event.isCancelled())
+        	return;
+
         for (CustomObject object : objects)
         {
             object.process(world, random, chunkX, chunkZ);
@@ -57,5 +65,11 @@ public class CustomObjectGen extends Resource
     {
         return "CustomObject(" + Txt.implode(objectNames, ",") + ")";
     }
+
+	@Override
+	protected ResourceEvent getResourceEvent(LocalWorld world, Random random,
+			int chunkX, int chunkZ, boolean hasGeneratedAVillage) {
+		return new ResourceEvent(CUSTOM_OBJECT, world, random, chunkX, chunkZ, 0, 0, hasGeneratedAVillage);
+	}
 
 }

--- a/common/src/com/khorn/terraincontrol/generator/resourcegens/DungeonGen.java
+++ b/common/src/com/khorn/terraincontrol/generator/resourcegens/DungeonGen.java
@@ -1,11 +1,14 @@
 package com.khorn.terraincontrol.generator.resourcegens;
 
-import com.khorn.terraincontrol.exception.InvalidResourceException;
-import com.khorn.terraincontrol.LocalWorld;
-import com.khorn.terraincontrol.TerrainControl;
+import static com.khorn.terraincontrol.events.ResourceEvent.Type.DUNGEON;
 
 import java.util.List;
 import java.util.Random;
+
+import com.khorn.terraincontrol.LocalWorld;
+import com.khorn.terraincontrol.TerrainControl;
+import com.khorn.terraincontrol.events.ResourceEvent;
+import com.khorn.terraincontrol.exception.InvalidResourceException;
 
 public class DungeonGen extends Resource
 {
@@ -37,4 +40,10 @@ public class DungeonGen extends Resource
     {
         return "Dungeon(" + frequency + "," + rarity + "," + minAltitude + "," + maxAltitude + ")";
     }
+
+	@Override
+	protected ResourceEvent getResourceEvent(LocalWorld world, Random random,
+			int chunkX, int chunkZ, boolean hasGeneratedAVillage) {
+		return new ResourceEvent(DUNGEON, world, random, chunkX, chunkZ, 0, 0, hasGeneratedAVillage);
+	}
 }

--- a/common/src/com/khorn/terraincontrol/generator/resourcegens/GrassGen.java
+++ b/common/src/com/khorn/terraincontrol/generator/resourcegens/GrassGen.java
@@ -1,8 +1,12 @@
 package com.khorn.terraincontrol.generator.resourcegens;
 
+import static com.khorn.terraincontrol.events.ResourceEvent.Type.GRASS;
+
+import com.khorn.terraincontrol.events.ResourceEvent;
 import com.khorn.terraincontrol.exception.InvalidResourceException;
 import com.khorn.terraincontrol.DefaultMaterial;
 import com.khorn.terraincontrol.LocalWorld;
+import com.khorn.terraincontrol.TerrainControl;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,8 +43,13 @@ public class GrassGen extends Resource
     }
 
     @Override
-    public void process(LocalWorld world, Random random, int chunkX, int chunkZ)
+    public void process(LocalWorld world, Random random, int chunkX, int chunkZ, boolean hasGeneratedAVillage)
     {
+        ResourceEvent event = getResourceEvent(world, random, chunkX, chunkZ, hasGeneratedAVillage);
+        TerrainControl.fireResourceEvent(event);
+        if (event.isCancelled())
+        	return;
+
         for (int t = 0; t < frequency; t++)
         {
             if (random.nextInt(100) >= rarity)
@@ -64,4 +73,10 @@ public class GrassGen extends Resource
     {
         return "Grass(" + makeMaterial(blockId) + "," + blockData + "," + frequency + "," + rarity + makeMaterial(sourceBlocks) + ")";
     }
+
+	@Override
+	protected ResourceEvent getResourceEvent(LocalWorld world, Random random,
+			int chunkX, int chunkZ, boolean hasGeneratedAVillage) {
+		return new ResourceEvent(GRASS, world, random, chunkX, chunkZ, blockId, blockData, hasGeneratedAVillage);
+	}
 }

--- a/common/src/com/khorn/terraincontrol/generator/resourcegens/LiquidGen.java
+++ b/common/src/com/khorn/terraincontrol/generator/resourcegens/LiquidGen.java
@@ -1,8 +1,11 @@
 package com.khorn.terraincontrol.generator.resourcegens;
 
+import static com.khorn.terraincontrol.events.ResourceEvent.Type.LIQUID;
+
 import com.khorn.terraincontrol.LocalWorld;
 import com.khorn.terraincontrol.TerrainControl;
 
+import com.khorn.terraincontrol.events.ResourceEvent;
 import com.khorn.terraincontrol.exception.InvalidResourceException;
 
 import java.util.ArrayList;
@@ -87,4 +90,10 @@ public class LiquidGen extends Resource
     {
         return "Liquid(" + makeMaterial(blockId, blockData) + "," + frequency + "," + rarity + "," + minAltitude + "," + maxAltitude + makeMaterial(sourceBlocks) + ")";
     }
+
+	@Override
+	protected ResourceEvent getResourceEvent(LocalWorld world, Random random,
+			int chunkX, int chunkZ, boolean hasGeneratedAVillage) {
+		return new ResourceEvent(LIQUID, world, random, chunkX, chunkZ, blockId, blockData, hasGeneratedAVillage);
+	}
 }

--- a/common/src/com/khorn/terraincontrol/generator/resourcegens/OreGen.java
+++ b/common/src/com/khorn/terraincontrol/generator/resourcegens/OreGen.java
@@ -1,11 +1,14 @@
 package com.khorn.terraincontrol.generator.resourcegens;
 
+import static com.khorn.terraincontrol.events.ResourceEvent.Type.ORE;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
 import com.khorn.terraincontrol.LocalWorld;
 import com.khorn.terraincontrol.TerrainControl;
+import com.khorn.terraincontrol.events.ResourceEvent;
 import com.khorn.terraincontrol.exception.InvalidResourceException;
 import com.khorn.terraincontrol.util.MathHelper;
 
@@ -102,4 +105,10 @@ public class OreGen extends Resource
     {
         return "Ore(" + makeMaterial(blockId, blockData) + "," + maxSize + "," + frequency + "," + rarity + "," + minAltitude + "," + maxAltitude + makeMaterial(sourceBlocks) + ")";
     }
+
+	@Override
+	protected ResourceEvent getResourceEvent(LocalWorld world, Random random,
+			int chunkX, int chunkZ, boolean hasGeneratedAVillage) {
+		return new ResourceEvent(ORE, world, random, chunkX, chunkZ, blockId, blockData, hasGeneratedAVillage);
+	}
 }

--- a/common/src/com/khorn/terraincontrol/generator/resourcegens/PlantGen.java
+++ b/common/src/com/khorn/terraincontrol/generator/resourcegens/PlantGen.java
@@ -1,5 +1,8 @@
 package com.khorn.terraincontrol.generator.resourcegens;
 
+import static com.khorn.terraincontrol.events.ResourceEvent.Type.PLANT;
+
+import com.khorn.terraincontrol.events.ResourceEvent;
 import com.khorn.terraincontrol.exception.InvalidResourceException;
 import com.khorn.terraincontrol.LocalWorld;
 import com.khorn.terraincontrol.TerrainControl;
@@ -58,4 +61,10 @@ public class PlantGen extends Resource
     {
         return "Plant(" + makeMaterial(blockId, blockData) + "," + frequency + "," + rarity + "," + minAltitude + "," + maxAltitude + makeMaterial(sourceBlocks) + ")";
     }
+
+	@Override
+	protected ResourceEvent getResourceEvent(LocalWorld world, Random random,
+			int chunkX, int chunkZ, boolean hasGeneratedAVillage) {
+		return new ResourceEvent(PLANT, world, random, chunkX, chunkZ, blockId, blockData, hasGeneratedAVillage);
+	}
 }

--- a/common/src/com/khorn/terraincontrol/generator/resourcegens/ReedGen.java
+++ b/common/src/com/khorn/terraincontrol/generator/resourcegens/ReedGen.java
@@ -1,7 +1,10 @@
 package com.khorn.terraincontrol.generator.resourcegens;
 
+import static com.khorn.terraincontrol.events.ResourceEvent.Type.REED;
+
 import com.khorn.terraincontrol.LocalWorld;
 import com.khorn.terraincontrol.TerrainControl;
+import com.khorn.terraincontrol.events.ResourceEvent;
 import com.khorn.terraincontrol.exception.InvalidResourceException;
 
 import java.util.ArrayList;
@@ -63,4 +66,10 @@ public class ReedGen extends Resource
     {
         return "Reed(" + makeMaterial(blockId, blockData) + "," + frequency + "," + rarity + "," + minAltitude + "," + maxAltitude + makeMaterial(sourceBlocks) + ")";
     }
+
+	@Override
+	protected ResourceEvent getResourceEvent(LocalWorld world, Random random,
+			int chunkX, int chunkZ, boolean hasGeneratedAVillage) {
+		return new ResourceEvent(REED, world, random, chunkX, chunkZ, blockId, blockData, hasGeneratedAVillage);
+	}
 }

--- a/common/src/com/khorn/terraincontrol/generator/resourcegens/Resource.java
+++ b/common/src/com/khorn/terraincontrol/generator/resourcegens/Resource.java
@@ -1,13 +1,17 @@
 package com.khorn.terraincontrol.generator.resourcegens;
 
+import static com.khorn.terraincontrol.events.ResourceEvent.Type.ICE;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import com.khorn.terraincontrol.DefaultMaterial;
 import com.khorn.terraincontrol.LocalWorld;
 import com.khorn.terraincontrol.TerrainControl;
 import com.khorn.terraincontrol.configuration.ConfigFunction;
 import com.khorn.terraincontrol.configuration.WorldConfig;
+import com.khorn.terraincontrol.events.ResourceEvent;
 import com.khorn.terraincontrol.exception.InvalidResourceException;
 
 /**
@@ -37,9 +41,15 @@ public abstract class Resource extends ConfigFunction<WorldConfig>
      * @param world
      * @param chunkX
      * @param chunkZ
+     * @param hasGeneratedAVillage 
      */
-    public void process(LocalWorld world, Random random, int chunkX, int chunkZ)
+    public void process(LocalWorld world, Random random, int chunkX, int chunkZ, boolean hasGeneratedAVillage)
     {
+        ResourceEvent event = getResourceEvent(world, random, chunkX, chunkZ, hasGeneratedAVillage);
+        TerrainControl.fireResourceEvent(event);
+        if (event.isCancelled())
+        	return;
+
         for (int t = 0; t < frequency; t++)
         {
             if (random.nextInt(100) > rarity)
@@ -50,7 +60,9 @@ public abstract class Resource extends ConfigFunction<WorldConfig>
         }
     }
     
-    /**
+    protected abstract ResourceEvent getResourceEvent(LocalWorld world, Random random, int chunkX, int chunkZ, boolean hasGeneratedAVillage);
+
+	/**
      * Convenience method for creating a resource. Used to create the default resources.
      * @param world
      * @param clazz

--- a/common/src/com/khorn/terraincontrol/generator/resourcegens/SmallLakeGen.java
+++ b/common/src/com/khorn/terraincontrol/generator/resourcegens/SmallLakeGen.java
@@ -1,11 +1,14 @@
 package com.khorn.terraincontrol.generator.resourcegens;
 
+import static com.khorn.terraincontrol.events.ResourceEvent.Type.SMALL_LAKE;
+
 import java.util.List;
 import java.util.Random;
 
 import com.khorn.terraincontrol.DefaultMaterial;
 import com.khorn.terraincontrol.LocalWorld;
 import com.khorn.terraincontrol.TerrainControl;
+import com.khorn.terraincontrol.events.ResourceEvent;
 import com.khorn.terraincontrol.exception.InvalidResourceException;
 
 public class SmallLakeGen extends Resource
@@ -18,6 +21,18 @@ public class SmallLakeGen extends Resource
     private int maxAltitude;
 
     @Override
+	public void process(LocalWorld world, Random random, int chunkX,
+			int chunkZ, boolean hasGeneratedAVillage) {
+        ResourceEvent event = getResourceEvent(world, random, chunkX, chunkZ, hasGeneratedAVillage);
+        TerrainControl.fireResourceEvent(event);
+        if (event.isCancelled())
+        	return;
+        
+        if (!hasGeneratedAVillage)
+    		super.process(world, random, chunkX, chunkZ, hasGeneratedAVillage);
+	}
+
+	@Override
     public void spawn(LocalWorld world, Random rand, int x, int z)
     {
         x -= 8;
@@ -131,4 +146,10 @@ public class SmallLakeGen extends Resource
     {
         return "SmallLake(" + makeMaterial(blockId, blockData) + "," + frequency + "," + rarity + "," + minAltitude + "," + maxAltitude + ")";
     }
+
+	@Override
+	protected ResourceEvent getResourceEvent(LocalWorld world, Random random,
+			int chunkX, int chunkZ, boolean hasGeneratedAVillage) {
+		return new ResourceEvent(SMALL_LAKE, world, random, chunkX, chunkZ, blockId, blockData, hasGeneratedAVillage);
+	}
 }

--- a/common/src/com/khorn/terraincontrol/generator/resourcegens/TreeGen.java
+++ b/common/src/com/khorn/terraincontrol/generator/resourcegens/TreeGen.java
@@ -1,5 +1,7 @@
 package com.khorn.terraincontrol.generator.resourcegens;
 
+import static com.khorn.terraincontrol.events.ResourceEvent.Type.TREE;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -7,6 +9,7 @@ import java.util.Random;
 import com.khorn.terraincontrol.LocalWorld;
 import com.khorn.terraincontrol.TerrainControl;
 import com.khorn.terraincontrol.customobjects.CustomObject;
+import com.khorn.terraincontrol.events.ResourceEvent;
 import com.khorn.terraincontrol.exception.InvalidResourceException;
 
 public class TreeGen extends Resource
@@ -16,8 +19,13 @@ public class TreeGen extends Resource
     private List<Integer> treeChances;
 
     @Override
-    public void process(LocalWorld world, Random random, int chunkX, int chunkZ)
+    public void process(LocalWorld world, Random random, int chunkX, int chunkZ, boolean hasGeneratedAVillage)
     {
+        ResourceEvent event = getResourceEvent(world, random, chunkX, chunkZ, hasGeneratedAVillage);
+        TerrainControl.fireResourceEvent(event);
+        if (event.isCancelled())
+        	return;
+
         for (int i = 0; i < frequency; i++)
         {
             for (int treeNumber = 0; treeNumber < trees.size(); treeNumber++)
@@ -80,4 +88,10 @@ public class TreeGen extends Resource
     {
         // Left blank, as process() already handles this
     }
+
+	@Override
+	protected ResourceEvent getResourceEvent(LocalWorld world, Random random,
+			int chunkX, int chunkZ, boolean hasGeneratedAVillage) {
+		return new ResourceEvent(TREE, world, random, chunkX, chunkZ, 0, 0, hasGeneratedAVillage);
+	}
 }

--- a/common/src/com/khorn/terraincontrol/generator/resourcegens/UnderWaterOreGen.java
+++ b/common/src/com/khorn/terraincontrol/generator/resourcegens/UnderWaterOreGen.java
@@ -1,10 +1,13 @@
 package com.khorn.terraincontrol.generator.resourcegens;
 
+import static com.khorn.terraincontrol.events.ResourceEvent.Type.UNDERWATER_ORE;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
 import com.khorn.terraincontrol.LocalWorld;
+import com.khorn.terraincontrol.events.ResourceEvent;
 import com.khorn.terraincontrol.exception.InvalidResourceException;
 
 public class UnderWaterOreGen extends Resource
@@ -65,4 +68,10 @@ public class UnderWaterOreGen extends Resource
     {
         return "UnderWaterOre(" + makeMaterial(blockId, blockData) + "," + size + "," + frequency + "," + rarity + makeMaterial(sourceBlocks) + ")";
     }
+
+	@Override
+	protected ResourceEvent getResourceEvent(LocalWorld world, Random random,
+			int chunkX, int chunkZ, boolean hasGeneratedAVillage) {
+		return new ResourceEvent(UNDERWATER_ORE, world, random, chunkX, chunkZ, blockId, blockData, hasGeneratedAVillage);
+	}
 }

--- a/common/src/com/khorn/terraincontrol/generator/resourcegens/UndergroundLakeGen.java
+++ b/common/src/com/khorn/terraincontrol/generator/resourcegens/UndergroundLakeGen.java
@@ -1,5 +1,8 @@
 package com.khorn.terraincontrol.generator.resourcegens;
 
+import static com.khorn.terraincontrol.events.ResourceEvent.Type.UNDERGROUND_LAKE;
+
+import com.khorn.terraincontrol.events.ResourceEvent;
 import com.khorn.terraincontrol.exception.InvalidResourceException;
 import com.khorn.terraincontrol.DefaultMaterial;
 import com.khorn.terraincontrol.LocalWorld;
@@ -84,4 +87,10 @@ public class UndergroundLakeGen extends Resource
     {
         return "UnderGroundLake(" + minSize + "," + maxSize + "," + frequency + "," + rarity + "," + minAltitude + "," + maxAltitude + ")";
     }
+
+	@Override
+	protected ResourceEvent getResourceEvent(LocalWorld world, Random random,
+			int chunkX, int chunkZ, boolean hasGeneratedAVillage) {
+		return new ResourceEvent(UNDERGROUND_LAKE, world, random, chunkX, chunkZ, 0, 0, hasGeneratedAVillage);
+	}
 }

--- a/common/src/com/khorn/terraincontrol/generator/resourcegens/VinesGen.java
+++ b/common/src/com/khorn/terraincontrol/generator/resourcegens/VinesGen.java
@@ -1,11 +1,14 @@
 package com.khorn.terraincontrol.generator.resourcegens;
 
+import static com.khorn.terraincontrol.events.ResourceEvent.Type.VINES;
+
 import java.util.List;
 import java.util.Random;
 
 import com.khorn.terraincontrol.DefaultMaterial;
 import com.khorn.terraincontrol.LocalWorld;
 import com.khorn.terraincontrol.TerrainControl;
+import com.khorn.terraincontrol.events.ResourceEvent;
 import com.khorn.terraincontrol.exception.InvalidResourceException;
 
 public class VinesGen extends Resource
@@ -84,4 +87,10 @@ public class VinesGen extends Resource
     {
         return "Vines(" + frequency + "," + rarity + "," + minAltitude + "," + maxAltitude + ")";
     }
+
+	@Override
+	protected ResourceEvent getResourceEvent(LocalWorld world, Random random,
+			int chunkX, int chunkZ, boolean hasGeneratedAVillage) {
+		return new ResourceEvent(VINES, world, random, chunkX, chunkZ, 0, 0, hasGeneratedAVillage);
+	}
 }

--- a/forge/src/com/khorn/terraincontrol/forge/EventManager.java
+++ b/forge/src/com/khorn/terraincontrol/forge/EventManager.java
@@ -1,0 +1,274 @@
+package com.khorn.terraincontrol.forge;
+
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.terraingen.DecorateBiomeEvent;
+import net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate;
+import net.minecraftforge.event.terraingen.OreGenEvent;
+import net.minecraftforge.event.terraingen.OreGenEvent.GenerateMinable;
+import net.minecraftforge.event.terraingen.PopulateChunkEvent;
+import net.minecraftforge.event.terraingen.PopulateChunkEvent.Populate;
+import net.minecraftforge.event.terraingen.TerrainGen;
+
+import com.khorn.terraincontrol.DefaultMaterial;
+import com.khorn.terraincontrol.events.ChunkEvent;
+import com.khorn.terraincontrol.events.EventHandler;
+import com.khorn.terraincontrol.events.PopulateEvent;
+import com.khorn.terraincontrol.events.ResourceEvent;
+
+import cpw.mods.fml.common.registry.GameRegistry;
+
+/**
+ * Translates TerrainControl events into MinecraftForge terrain events
+ * 
+ */
+public class EventManager extends EventHandler
+{
+    private static Decorate.EventType getAboveWaterEventType(ResourceEvent event)
+    {
+        if (event.getBlockId() == DefaultMaterial.WATER_LILY.id)
+            return Decorate.EventType.LILYPAD;
+        return Decorate.EventType.CUSTOM;
+    }
+    
+    private static Decorate.EventType getCactusEventType(ResourceEvent event)
+    {
+        if (event.getBlockId() == DefaultMaterial.CACTUS.id)
+            return Decorate.EventType.CACTUS;
+        return Decorate.EventType.CUSTOM;
+    }
+
+    private static Decorate.EventType getGrassEventType(ResourceEvent event)
+    {
+        if (event.getBlockId() == DefaultMaterial.LONG_GRASS.id)
+            return Decorate.EventType.GRASS;
+        if (event.getBlockId() == DefaultMaterial.DEAD_BUSH.id)
+            return Decorate.EventType.DEAD_BUSH;
+        return Decorate.EventType.CUSTOM;
+    }
+    
+    private static Populate.EventType getLiquidEventType(ResourceEvent event)
+    {
+        return event.getBlockId() == DefaultMaterial.WATER.id ? Populate.EventType.LAKE
+             : event.getBlockId() == DefaultMaterial.LAVA.id ? Populate.EventType.LAVA
+             : Populate.EventType.CUSTOM;
+    }
+
+    private static GenerateMinable.EventType getOreEventType(ResourceEvent event)
+    {
+        if (event.getBlockId() == DefaultMaterial.COAL_ORE.id)
+            return GenerateMinable.EventType.COAL;
+        if (event.getBlockId() == DefaultMaterial.DIAMOND_ORE.id)
+            return GenerateMinable.EventType.DIAMOND;
+        if (event.getBlockId() == DefaultMaterial.DIRT.id)
+            return GenerateMinable.EventType.DIRT;
+        if (event.getBlockId() == DefaultMaterial.GOLD_ORE.id)
+            return GenerateMinable.EventType.GOLD;
+        if (event.getBlockId() == DefaultMaterial.GRAVEL.id)
+            return GenerateMinable.EventType.GRAVEL;
+        if (event.getBlockId() == DefaultMaterial.IRON_ORE.id)
+            return GenerateMinable.EventType.IRON;
+        if (event.getBlockId() == DefaultMaterial.LAPIS_ORE.id)
+            return GenerateMinable.EventType.LAPIS;
+        if (event.getBlockId() == DefaultMaterial.REDSTONE_ORE.id)
+            return GenerateMinable.EventType.REDSTONE;
+        return GenerateMinable.EventType.CUSTOM;
+    }
+    
+    private static Decorate.EventType getPlantEventType(ResourceEvent event)
+    {
+        if (event.getBlockId() == DefaultMaterial.RED_ROSE.id || event.getBlockId() == DefaultMaterial.YELLOW_FLOWER.id)
+            return Decorate.EventType.FLOWERS;
+        if (event.getBlockId() == DefaultMaterial.PUMPKIN.id)
+            return Decorate.EventType.PUMPKIN;
+        if (event.getBlockId() == DefaultMaterial.BROWN_MUSHROOM.id || event.getBlockId() == DefaultMaterial.RED_MUSHROOM.id)
+            return Decorate.EventType.SHROOM;
+        return Decorate.EventType.CUSTOM;
+    }
+
+    private static Decorate.EventType getReedEventType(ResourceEvent event) {
+        if (event.getBlockId() == DefaultMaterial.SUGAR_CANE_BLOCK.id)
+            return Decorate.EventType.REED;
+        return Decorate.EventType.CUSTOM;
+    }
+
+    SingleWorld worldTC;
+
+    World worldMC;
+
+    private boolean hasDecorationBegun;
+
+    private boolean hasOreGenBegun;
+
+    public EventManager(SingleWorld worldTC, World worldMC)
+    {
+        this.worldTC = worldTC;
+        this.worldMC = worldMC;
+    }
+
+    private void closeDecoration(PopulateEvent event) {
+        if (hasDecorationBegun)
+        {
+            MinecraftForge.EVENT_BUS.post(new DecorateBiomeEvent.Post(worldMC, event.getRandom(), event.getChunkX(), event.getChunkZ()));
+            hasDecorationBegun = false;
+        }
+    }
+
+    private void closeOreGeneration(ChunkEvent event) {
+        if (hasOreGenBegun)
+        {
+            MinecraftForge.ORE_GEN_BUS.post(new OreGenEvent.Post(worldMC, event.getRandom(), event.getChunkX(), event.getChunkZ()));
+            hasOreGenBegun = false;
+        }
+    }
+
+    private Decorate.EventType getDecorateEventType(ResourceEvent event)
+    {
+        switch(event.getType())
+        {
+        case CACTUS:
+            return getCactusEventType(event);
+        case ABOVE_WATER:
+            return getAboveWaterEventType(event);
+        case GRASS:
+            return getGrassEventType(event);
+        case PLANT:
+            return getPlantEventType(event);
+        case REED:
+            return getReedEventType(event);
+        case TREE:
+            return Decorate.EventType.TREE;
+        case UNDERWATER_ORE:
+            if (event.getBlockId() == DefaultMaterial.CLAY.id)
+                return Decorate.EventType.CLAY;
+            if (event.getBlockId() == DefaultMaterial.SAND.id)
+                return Decorate.EventType.SAND;
+            break;
+         default:
+             // Use CUSTOM type
+        }
+        return Decorate.EventType.CUSTOM;
+    }
+
+    @Override
+    public void onPopulateEvent(PopulateEvent event)
+    {
+        if (event.getWorld() != worldTC)
+            return;
+
+        boolean triggerFMLGeneration = false;
+        
+        final PopulateChunkEvent forgeEvent;
+        switch (event.getType())
+        {
+        case BEGIN:
+            resetState();
+            forgeEvent = new PopulateChunkEvent.Pre(worldTC.getChunkGenerator(), worldMC, event.getRandom(), event.getChunkX(), event.getChunkZ(), false);
+            break;
+        default: // END
+            closeOreGeneration(event);
+            closeDecoration(event);
+            forgeEvent = new PopulateChunkEvent.Post(worldTC.getChunkGenerator(), worldMC, event.getRandom(), event.getChunkX(), event.getChunkZ(), false);
+            triggerFMLGeneration = true;
+        }
+        MinecraftForge.EVENT_BUS.post(forgeEvent);
+        
+        if (triggerFMLGeneration)
+            GameRegistry.generateWorld(event.getChunkX(), event.getChunkZ(), worldMC, worldTC.getChunkGenerator(), worldTC.getChunkGenerator());
+    }
+
+    @Override
+    public void onResourceEvent(ResourceEvent event)
+    {
+        if (event.getWorld() != worldTC)
+            return;
+
+        boolean isDecorationEvent = false;
+
+        Populate.EventType forgeEventType = Populate.EventType.CUSTOM;
+        switch (event.getType())
+        {
+        case DUNGEON:
+            forgeEventType = Populate.EventType.DUNGEON;
+            break;
+        case SMALL_LAKE:
+        case LIQUID:
+           forgeEventType = getLiquidEventType(event);
+            break;
+        case ABOVE_WATER:
+        case CACTUS:
+        case GRASS:
+        case ORE:
+        case PLANT:
+        case REED:
+        case TREE:
+        case UNDERWATER_ORE:
+            isDecorationEvent = true;
+            break;
+        default:
+            // Use custom type.
+        }
+        if (!isDecorationEvent)
+            postForgeEvent(event, forgeEventType);
+        else
+            processDecorationEvent(event);
+    }
+    
+    private void openDecoration(ResourceEvent event) {
+        if (!hasDecorationBegun)
+        {
+            MinecraftForge.EVENT_BUS.post(new DecorateBiomeEvent.Pre(worldMC, event.getRandom(), event.getChunkX(), event.getChunkZ()));
+            hasDecorationBegun = true;
+        }
+    }
+
+    private void postForgeEvent(ResourceEvent event, Decorate.EventType forgeEventType)
+    {
+        closeOreGeneration(event);
+        if (!TerrainGen.decorate(worldMC, event.getRandom(), event.getChunkX(), event.getChunkZ(), forgeEventType))
+            event.cancel();
+    }
+
+    private void postForgeEvent(ResourceEvent event, Populate.EventType forgeEventType)
+    {
+        if (hasDecorationBegun)
+        {
+            MinecraftForge.EVENT_BUS.post(new DecorateBiomeEvent.Post(worldMC, event.getRandom(), event.getChunkX(), event.getChunkZ()));
+            hasDecorationBegun = false;
+        }
+        if (!TerrainGen.populate(worldTC.getChunkGenerator(), worldMC, event.getRandom(), event.getChunkX(), event.getChunkZ(), event.hasGeneratedAVillage(), forgeEventType))
+            event.cancel();
+    }
+
+    private void postForgeOreGenEvent(ResourceEvent event)
+    {
+        if (!hasOreGenBegun)
+        {
+            MinecraftForge.ORE_GEN_BUS.post(new OreGenEvent.Pre(worldMC, event.getRandom(), event.getChunkX(), event.getChunkZ()));
+            hasOreGenBegun = true;
+        }
+        if (!TerrainGen.generateOre(worldMC, event.getRandom(), null, event.getChunkX(), event.getChunkZ(), getOreEventType(event)))
+        {
+            event.cancel();
+        }
+    }
+
+    private void processDecorationEvent(ResourceEvent event)
+    {
+        openDecoration(event);
+        switch(event.getType())
+        {
+        case ORE:
+            postForgeOreGenEvent(event);
+            break;
+        default:
+            postForgeEvent(event, getDecorateEventType(event));
+       }
+    }
+
+    private void resetState()
+    {
+        hasDecorationBegun = false;
+        hasOreGenBegun = false;
+    }
+}


### PR DESCRIPTION
- Added Populate events to signal beginning and end of chunk population
- Added Resource events to signal resource spawns and allow cancellation
- Added hook in forge wrapper to allow ModLoader style chunk decoration events

This change gives other mods the power to affect terrain generation in various ways and makes the forge version of TerrainControl compatible with other Forge mods that generate terrain and terrain features.
