### PR TITLE
Added Recursive BOB Loading

### DIFF
--- a/common/src/com/khorn/terraincontrol/customobjects/CustomObjectManager.java
+++ b/common/src/com/khorn/terraincontrol/customobjects/CustomObjectManager.java
@@ -10,6 +10,7 @@ import com.khorn.terraincontrol.generator.resourcegens.TreeType;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
 
 /**
  * This class is the registry for the custom object types. It also stores
@@ -145,27 +146,45 @@ public class CustomObjectManager
     }
 
     /**
-     * Returns a Map with all CustomObjects in a directory in it. The Map will
-     * have the lowercase object name as a key.
+     * Returns a Map with all CustomObjects in a directory and its sub-directories
+     * in it. The Map will have the lowercase object name as a key.
      *
      * @param directory The directory to load from.
      * @return
      */
     public Map<String, CustomObject> loadObjects(File directory)
     {
+        return loadObjects(directory, true);
+    }
+    
+    /**
+     * Returns a Map with all CustomObjects in a directory and its sub-directories
+     * in it. The Map will have the lowercase object name as a key.
+     *
+     * @param directory The directory to load from.
+     * @param enableObjects whether or not to enable objects 
+     * @return
+     */
+    public Map<String, CustomObject> loadObjects(File directory, boolean enableObjects)
+    {
         if (!directory.isDirectory())
         {
             throw new IllegalArgumentException("Given file is not a directory: " + directory.getAbsolutePath());
         }
 
-        // Load all objects from the files
+        // Load all objects from the files and folders under @directory
         Map<String, CustomObject> objects = new HashMap<String, CustomObject>();
         for (File file : directory.listFiles())
         {
             // Get name and extension
             String fileName = file.getName();
             int index = fileName.lastIndexOf('.');
-            if (index != -1)
+            // If we come across a directory decend into it without enabling the objects
+            if (file.isDirectory()) 
+            {
+                objects.putAll(this.loadObjects(file, false));
+            }
+            else if (index != -1)
             {
                 String objectType = fileName.substring(index + 1, fileName.length());
                 String objectName = fileName.substring(0, index);
@@ -179,12 +198,16 @@ public class CustomObjectManager
             }
         }
 
-        // Enable all the objects
-        for (CustomObject object : objects.values())
+        // Enable all the objects if desired
+        if (enableObjects)
         {
-            object.onEnable(objects);
+            TerrainControl.log(Level.INFO, ("[BOB ENABLE INFO] {{BEGIN}} " + directory.getParentFile().getName().toUpperCase() + File.separator + directory.getName()).toUpperCase());
+            for (CustomObject object : objects.values())
+            {
+                object.onEnable(objects);
+            }
+            TerrainControl.log(Level.INFO, ("[BOB ENABLE INFO] {{ END }} " + directory.getParentFile().getName().toUpperCase() + File.separator + directory.getName()).toUpperCase());
         }
-
         return objects;
     }
 


### PR DESCRIPTION
I made these changes for myself a while back I figured they might be useful to the community 
- Added loading of `CustomObject`s from all subfolders of parent BOB 
  directory 
  - Loaded `CustomObject`s are not enabled until after all recursive calls 
    have been made 

Global object loading looks something like this... 
![2013-07-16_1521-a](https://f.cloud.github.com/assets/1635159/807378/65dd6528-ee4d-11e2-8d27-a1c014681a7b.png) 

Individual World Loading looks something like this...(Notice the Number error in between: That is another change I made to help me find errors in files... I will be making a pull request for that too
![2013-07-16_1521-b](https://f.cloud.github.com/assets/1635159/807380/685211e6-ee4d-11e2-9aff-095f635d8e9e.png) 
