### PR TITLE
Better Logging of Config load errors

### DIFF
--- a/common/src/com/khorn/terraincontrol/biomelayers/layers/LayerFromImage.java
+++ b/common/src/com/khorn/terraincontrol/biomelayers/layers/LayerFromImage.java
@@ -33,7 +33,7 @@ public class LayerFromImage extends Layer
 
         try
         {
-            File image = new File(config.SettingsDir, config.imageFile);
+            File image = new File(config.file, config.imageFile);
             BufferedImage map = ImageIO.read(image);
             this.mapHeight = map.getHeight(null);
             this.mapWidth = map.getWidth(null);

--- a/common/src/com/khorn/terraincontrol/configuration/BiomeConfig.java
+++ b/common/src/com/khorn/terraincontrol/configuration/BiomeConfig.java
@@ -106,7 +106,6 @@ public class BiomeConfig extends ConfigFile
     public LocalBiome Biome;
 
     public WorldConfig worldConfig;
-    public String name;
 
     // Spawn Config
     public boolean spawnMonstersAddDefaults = true;

--- a/common/src/com/khorn/terraincontrol/configuration/ConfigFile.java
+++ b/common/src/com/khorn/terraincontrol/configuration/ConfigFile.java
@@ -6,10 +6,14 @@ import com.khorn.terraincontrol.TerrainControl;
 import java.awt.Color;
 import java.io.*;
 import java.util.*;
+import java.util.logging.Level;
 
 public abstract class ConfigFile
 {
     private BufferedWriter settingsWriter;
+    
+    public String name;
+    public File file;
 
     /**
      * Stores all the settings. Settings like Name:Value or Name=Value are stored as name, Value and settings like Function(a, b, c) are stored as function(a, b, c), lineNumber
@@ -91,24 +95,32 @@ public abstract class ConfigFile
                 }
             }
         } else
-            sayFileNotFound(f);
+            logFileNotFound(f);
     }
 
     // -------------------------------------------- //
-    // SAY STUFF
+    // LOG STUFF
     // -------------------------------------------- //
 
-    protected void sayNotFound(String settingsName)
+    protected void logSettingNotFound(String settingsName)
     {
-        // TerrainControl.log("Value " + settingsName + " not found.");
+        // TerrainControl.log("`"+settingsName + "` in `" + this.file.getName() + "` was not found.");
     }
-
-    protected void sayHadWrongValue(String settingsName)
+    protected void logSettingValueInvalid(String settingsName)
     {
-        TerrainControl.log(settingsName + " had wrong value");
+         TerrainControl.log(Level.WARNING, getSettingValueInvalidError(settingsName));
     }
-
-    protected void sayFileNotFound(File file)
+    protected void logSettingValueInvalid(String settingsName, Exception e)
+    {
+        TerrainControl.log(Level.WARNING, e.getClass().getSimpleName() + " :: " + getSettingValueInvalidError(settingsName));
+    }
+    
+    private String getSettingValueInvalidError(String settingsName)
+    {
+        return "Value of "+settingsName + ": `"+this.settingsCache.get(settingsName)+"' in " + this.file.getName() + " is not valid.";
+    }
+    
+    protected void logFileNotFound(File file)
     {
         TerrainControl.log("File not found: " + file.getName());
     }
@@ -128,7 +140,7 @@ public abstract class ConfigFile
             return WeightedMobSpawnGroup.fromJson(json);
         }
 
-        sayNotFound(settingsName);
+        logSettingNotFound(settingsName);
 
         return defaultValue;
     }
@@ -146,7 +158,7 @@ public abstract class ConfigFile
             Collections.addAll(out, this.settingsCache.get(settingsName).split(","));
             return out;
         }
-        sayNotFound(settingsName);
+        logSettingNotFound(settingsName);
         return defaultValue;
     }
 
@@ -160,10 +172,10 @@ public abstract class ConfigFile
                 return Integer.valueOf(this.settingsCache.get(settingsName));
             } catch (NumberFormatException e)
             {
-                sayHadWrongValue(settingsName);
+                logSettingValueInvalid(settingsName, e);
             }
         }
-        sayNotFound(settingsName);
+        logSettingNotFound(settingsName);
         return defaultValue;
     }
 
@@ -182,10 +194,10 @@ public abstract class ConfigFile
                 return Long.parseLong(value);
             } catch (NumberFormatException e)
             {
-                sayHadWrongValue(settingsName);
+                logSettingValueInvalid(settingsName, e);
             }
         }
-        sayNotFound(settingsName);
+        logSettingNotFound(settingsName);
         return defaultValue;
     }
 
@@ -204,10 +216,10 @@ public abstract class ConfigFile
                 return (byte) number;
             } catch (NumberFormatException e)
             {
-                sayHadWrongValue(settingsName);
+                logSettingValueInvalid(settingsName, e);
             }
         }
-        sayNotFound(settingsName);
+        logSettingNotFound(settingsName);
         return defaultValue;
     }
 
@@ -218,7 +230,7 @@ public abstract class ConfigFile
         {
             return this.settingsCache.get(settingsName);
         }
-        sayNotFound(settingsName);
+        logSettingNotFound(settingsName);
         return defaultValue;
     }
 
@@ -232,10 +244,10 @@ public abstract class ConfigFile
                 return Double.valueOf(this.settingsCache.get(settingsName));
             } catch (NumberFormatException e)
             {
-                sayHadWrongValue(settingsName);
+                logSettingValueInvalid(settingsName, e);
             }
         }
-        sayNotFound(settingsName);
+        logSettingNotFound(settingsName);
         return defaultValue;
     }
 
@@ -248,12 +260,12 @@ public abstract class ConfigFile
             try
             {
                 color = Color.decode(this.settingsCache.get(settingsName));
-            } catch (NumberFormatException ex)
+            } catch (NumberFormatException e)
             {
-                sayHadWrongValue(settingsName);
+                logSettingValueInvalid(settingsName, e);
             }
         } else
-            sayNotFound(settingsName);
+            logSettingNotFound(settingsName);
         return color.getRGB() & 0xFFFFFF;
     }
 
@@ -267,10 +279,10 @@ public abstract class ConfigFile
                 return Float.valueOf(this.settingsCache.get(settingsName));
             } catch (NumberFormatException e)
             {
-                sayHadWrongValue(settingsName);
+                logSettingValueInvalid(settingsName, e);
             }
         }
-        sayNotFound(settingsName);
+        logSettingNotFound(settingsName);
         return defaultValue;
     }
 
@@ -281,7 +293,7 @@ public abstract class ConfigFile
         {
             return Boolean.valueOf(this.settingsCache.get(settingsName));
         }
-        sayNotFound(settingsName);
+        logSettingNotFound(settingsName);
         return defaultValue;
     }
 
@@ -304,12 +316,12 @@ public abstract class ConfigFile
                     if (enumName.toLowerCase().equals(value) || enumName.equals(value))
                         return (Enum<?>) enumValue;
                 }
-                sayHadWrongValue(settingsName);
+                logSettingValueInvalid(settingsName);
 
             }
 
         }
-        sayNotFound(settingsName);
+        logSettingNotFound(settingsName);
         return defaultValue;
 
     }

--- a/common/src/com/khorn/terraincontrol/configuration/WorldConfig.java
+++ b/common/src/com/khorn/terraincontrol/configuration/WorldConfig.java
@@ -146,13 +146,11 @@ public class WorldConfig extends ConfigFile
     public int objectSpawnRatio;
     public File customObjectsDirectory;
 
-    public File SettingsDir;
     public ConfigMode SettingsMode;
 
     public boolean isDeprecated = false;
     public WorldConfig newSettings = null;
 
-    public String WorldName;
     public TerrainMode ModeTerrain;
     public Class<? extends BiomeGenerator> biomeMode;
 
@@ -168,10 +166,10 @@ public class WorldConfig extends ConfigFile
 
     public WorldConfig(File settingsDir, LocalWorld world, boolean checkOnly)
     {
-        this.SettingsDir = settingsDir;
-        this.WorldName = world.getName();
+        this.file = settingsDir;
+        this.name = world.getName();
 
-        File settingsFile = new File(this.SettingsDir, TCDefaultValues.WorldSettingsName.stringValue());
+        File settingsFile = new File(this.file, TCDefaultValues.WorldSettingsName.stringValue());
 
         this.readSettingsFile(settingsFile);
         this.renameOldSettings();
@@ -193,7 +191,7 @@ public class WorldConfig extends ConfigFile
 
         world.setHeightBits(this.worldHeightBits);
 
-        File BiomeFolder = new File(SettingsDir, TCDefaultValues.WorldBiomeConfigDirectoryName.stringValue());
+        File BiomeFolder = new File(file, TCDefaultValues.WorldBiomeConfigDirectoryName.stringValue());
         if (!BiomeFolder.exists())
         {
             if (!BiomeFolder.mkdir())
@@ -280,11 +278,11 @@ public class WorldConfig extends ConfigFile
 
     private void ReadWorldCustomObjects()
     {
-        customObjectsDirectory = new File(this.SettingsDir, TCDefaultValues.BO_WorldDirectoryName.stringValue());
+        customObjectsDirectory = new File(this.file, TCDefaultValues.BO_WorldDirectoryName.stringValue());
         
-        File oldCustomObjectsDirectory = new File(SettingsDir, "BOBPlugins");
+        File oldCustomObjectsDirectory = new File(file, "BOBPlugins");
         if (oldCustomObjectsDirectory.exists()) {
-            if (!oldCustomObjectsDirectory.renameTo(new File(SettingsDir, TCDefaultValues.BO_WorldDirectoryName.stringValue())))
+            if (!oldCustomObjectsDirectory.renameTo(new File(file, TCDefaultValues.BO_WorldDirectoryName.stringValue())))
             {
                 TerrainControl.log(Level.WARNING, "Fould old BOBPlugins folder, but it cannot be renamed to WorldObjects.");
                 TerrainControl.log(Level.WARNING, "Please move the BO2s manually and delete BOBPlugins afterwards.");
@@ -341,7 +339,7 @@ public class WorldConfig extends ConfigFile
 
         if (this.biomeMode == TerrainControl.getBiomeModeManager().FROM_IMAGE)
         {
-            File mapFile = new File(SettingsDir, imageFile);
+            File mapFile = new File(file, imageFile);
             if (!mapFile.exists())
             {
                 TerrainControl.log("Biome map file not found. Switching BiomeMode to Normal");
@@ -945,7 +943,7 @@ public class WorldConfig extends ConfigFile
     public void Serialize(DataOutputStream stream) throws IOException
     {
         // General information
-        writeStringToStream(stream, this.WorldName);
+        writeStringToStream(stream, this.name);
 
         stream.writeInt(this.WorldFog);
         stream.writeInt(this.WorldNightFog);
@@ -973,7 +971,7 @@ public class WorldConfig extends ConfigFile
     public WorldConfig(DataInputStream stream, LocalWorld world) throws IOException
     {
         // General information
-        this.WorldName = readStringFromStream(stream);
+        this.name = readStringFromStream(stream);
 
         this.WorldFog = stream.readInt();
         this.WorldNightFog = stream.readInt();

--- a/common/src/com/khorn/terraincontrol/customobjects/bo2/BO2.java
+++ b/common/src/com/khorn/terraincontrol/customobjects/bo2/BO2.java
@@ -22,8 +22,6 @@ public class BO2 extends ConfigFile implements CustomObject
 
     public BO2[] groupObjects = null;
 
-    public String name;
-
     public HashSet<String> spawnInBiome;
 
     public String version;

--- a/common/src/com/khorn/terraincontrol/customobjects/bo3/BO3Config.java
+++ b/common/src/com/khorn/terraincontrol/customobjects/bo3/BO3Config.java
@@ -18,8 +18,6 @@ import java.util.Map;
 
 public class BO3Config extends ConfigFile
 {
-    public File file;
-    public String name;
     public Map<String, CustomObject> otherObjectsInDirectory;
 
     public String author;
@@ -97,7 +95,7 @@ public class BO3Config extends ConfigFile
     }
 
     @Override
-    public void sayFileNotFound(File file)
+    public void logFileNotFound(File file)
     {
         // Ignore
     }


### PR DESCRIPTION
- The `file` attribute is now inherited from ConfigFile by all children
- Refactored `SettingsDir` in WorldConfig to `file` so that it can inherit from ConfigFile
- sayNotFound method in ConfigFile has been renamed logSettingNotFound
- sayHadWrongValue method in ConfigFile has been renamed logSettingValueInvalid
- sayFileNotFound method in ConfigFile has been renamed logFileNotFound
- logSettingValueInvalid and logSettingNotFound are now more helpful

Changes appear in the logs like the below NumberFormatException
![2013-07-16_1521-b](https://f.cloud.github.com/assets/1635159/807380/685211e6-ee4d-11e2-9aff-095f635d8e9e.png) 

Prior to change this line would have said: 
[[TerrainControl]] sourceblock had wrong value
