### PR TITLE
Removed call to GameRegistry.generateWorld from Forge event manager.

### DIFF
--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/events/EventManager.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/events/EventManager.java
@@ -131,8 +131,7 @@ public class EventManager extends EventHandler
                 blockZ, villageInChunk);
         MinecraftForge.EVENT_BUS.post(forgeEvent);
 
-        // Population close (FML and ModLoader style)
-        GameRegistry.generateWorld(chunkX, chunkZ, world.getWorld(), world.getChunkGenerator(), world.getChunkGenerator());
+        // There is no need to call GameRegistry.generateWorld, because it is done by the Chunk Provider in Forge.
     }
 
     private Decorate.EventType getDecorateEventType(LocalMaterialData block)


### PR DESCRIPTION
Fixes #294. On my end, also fixes #209, given correct config options in
Underground Biomes.
