### PR TITLE
Fix Custom Biomes not spawning as expected

### DIFF
--- a/common/src/main/java/com/khorn/terraincontrol/generator/biome/layers/LayerFactory.java
+++ b/common/src/main/java/com/khorn/terraincontrol/generator/biome/layers/LayerFactory.java
@@ -201,7 +201,8 @@ public final class LayerFactory
                     for (String islandInName : biomeConfig.isleInBiome)
                     {
                         int islandIn = world.getBiomeByName(islandInName).getIds().getGenerationId();
-                        biomeCanSpawnIn[islandIn] = true;
+                        if (islandIn != DefaultBiome.OCEAN.Id)
+                    	    biomeCanSpawnIn[islandIn] = true;
                     }
 
                     int chance = (worldConfig.BiomeRarityScale + 1) - biomeConfig.biomeRarityWhenIsle;
@@ -340,7 +341,8 @@ public final class LayerFactory
                     for (String islandInName : biomeConfig.isleInBiome)
                     {
                         int islandIn = world.getBiomeByName(islandInName).getIds().getGenerationId();
-                        biomeCanSpawnIn[islandIn] = true;
+                        if (islandIn != DefaultBiome.OCEAN.Id)
+                	        biomeCanSpawnIn[islandIn] = true;
                     }
 
                     int chance = (worldConfig.BiomeRarityScale + 1) - biomeConfig.biomeRarityWhenIsle;


### PR DESCRIPTION
I downloaded 2.7.2 and replaced four files (LayerFactory.java, LayerBiomeInBiome.java, Layer.java, LayerMixWithRiver.java) with new ones from the master branch (they were changed in the "Use a single layer for isles" commit). I re-added a few lines that were removed after 2.7.2. With these lines in MCPitman's Biome Bundle spawns perfectly, without them the world is screwed up and is mostly deep ocean biomes. Only tested this with the Forge 1.7.10 build I made (its generated worlds look identical to 2.7.2 + Forge 1.8 tho). May want to test this for 1.9!