### PR TITLE
Use original biome size and rarity for BeforeGroups

### DIFF
--- a/common/src/main/java/com/khorn/terraincontrol/generator/biome/layers/LayerFactory.java
+++ b/common/src/main/java/com/khorn/terraincontrol/generator/biome/layers/LayerFactory.java
@@ -192,7 +192,7 @@ public final class LayerFactory
 
                 BiomeConfig biomeConfig = biome.getBiomeConfig();
 
-                if (biomeConfig.biomeSizeWhenIsle == depth
+                if (biomeConfig.biomeSize == depth
                         && worldConfig.IsleBiomes.contains(biomeConfig.getName())
                         && biomeConfig.isleInBiome != null)
                 {
@@ -205,11 +205,11 @@ public final class LayerFactory
                     	    biomeCanSpawnIn[islandIn] = true;
                     }
 
-                    int chance = (worldConfig.BiomeRarityScale + 1) - biomeConfig.biomeRarityWhenIsle;
+                    int chance = (worldConfig.BiomeRarityScale + 1) - biomeConfig.biomeRarity;
                     layerBiomeIsle.addIsle(biome, chance, biomeCanSpawnIn);
                 }
 
-                if (biomeConfig.biomeSizeWhenBorder == depth
+                if (biomeConfig.biomeSize == depth
                         && worldConfig.BorderBiomes.contains(biomeConfig.getName())
                         && biomeConfig.biomeIsBorder != null)
                 {


### PR DESCRIPTION
To make sure that worlds using BeforeGroups spawn just like they did before TC 2.7.2 use the original values for biome size and rarity, not biomeSizeWhenIsle, biomeRarityWhenIsle and biomeSizeWhenBorder.when using BeforeGroups