### PR TITLE
Revert LayerFactory

### DIFF
--- a/common/src/main/java/com/khorn/terraincontrol/generator/biome/layers/LayerFactory.java
+++ b/common/src/main/java/com/khorn/terraincontrol/generator/biome/layers/LayerFactory.java
@@ -200,9 +200,7 @@ public final class LayerFactory
                     boolean[] biomeCanSpawnIn = new boolean[1024];
                     for (String islandInName : biomeConfig.isleInBiome)
                     {
-                        int islandIn = world.getBiomeByName(islandInName).getIds().getGenerationId();
-                        if (islandIn != DefaultBiome.OCEAN.Id)
-                    	    biomeCanSpawnIn[islandIn] = true;
+            	        biomeCanSpawnIn[world.getBiomeByName(islandInName).getIds().getGenerationId()] = true;
                     }
 
                     int chance = (worldConfig.BiomeRarityScale + 1) - biomeConfig.biomeRarity;
@@ -340,9 +338,7 @@ public final class LayerFactory
                     boolean[] biomeCanSpawnIn = new boolean[1024];
                     for (String islandInName : biomeConfig.isleInBiome)
                     {
-                        int islandIn = world.getBiomeByName(islandInName).getIds().getGenerationId();
-                        if (islandIn != DefaultBiome.OCEAN.Id)
-                	        biomeCanSpawnIn[islandIn] = true;
+            	        biomeCanSpawnIn[world.getBiomeByName(islandInName).getIds().getGenerationId()] = true;
                     }
 
                     int chance = (worldConfig.BiomeRarityScale + 1) - biomeConfig.biomeRarityWhenIsle;


### PR DESCRIPTION
I've been reviewing the code and I think I understand it a little bit better now. The real problem turned out to be using biomeSizeWhenIsle, biomeRarityWhenIsle and biomeSizeWhenBorder with BeforeGroups mode, as you know their values for some reason weren't being set correctly. The changes i made earlier (addition of "if (islandIn != DefaultBiome.OCEAN.Id)" were actually wrong and should be undone, your old code was probably working just fine! Have done basic testing, looks good, I'll do much more testing in the next few hours, if anything pops up I'll ammend this pull request, otherwise you can assume tests were successful.