### PR TITLE
Fix for no isles in ocean bug

### DIFF
--- a/common/src/main/java/com/khorn/terraincontrol/generator/biome/layers/LayerFactory.java
+++ b/common/src/main/java/com/khorn/terraincontrol/generator/biome/layers/LayerFactory.java
@@ -198,15 +198,19 @@ public final class LayerFactory
                 {
                     haveIsle = true;
                     boolean[] biomeCanSpawnIn = new boolean[1024];
+                    boolean inOcean = false;
                     for (String islandInName : biomeConfig.isleInBiome)
                     {
                         int islandIn = world.getBiomeByName(islandInName).getIds().getGenerationId();
-                        if (islandIn != DefaultBiome.OCEAN.Id)
-                    	    biomeCanSpawnIn[islandIn] = true;
+                        if (islandIn == DefaultBiome.OCEAN.Id)
+                        {
+                        	inOcean = true;
+                        } else {
+                        	biomeCanSpawnIn[islandIn] = true;
+                        }
                     }
-
                     int chance = (worldConfig.BiomeRarityScale + 1) - biomeConfig.biomeRarity;
-                    layerBiomeIsle.addIsle(biome, chance, biomeCanSpawnIn);
+                    layerBiomeIsle.addIsle(biome, chance, biomeCanSpawnIn, inOcean);
                 }
 
                 if (biomeConfig.biomeSize == depth
@@ -338,15 +342,20 @@ public final class LayerFactory
                 {
                     haveIsle = true;
                     boolean[] biomeCanSpawnIn = new boolean[1024];
+                    boolean inOcean = false;
                     for (String islandInName : biomeConfig.isleInBiome)
                     {
                         int islandIn = world.getBiomeByName(islandInName).getIds().getGenerationId();
-                        if (islandIn != DefaultBiome.OCEAN.Id)
-                	        biomeCanSpawnIn[islandIn] = true;
+                        if (islandIn == DefaultBiome.OCEAN.Id)
+                        {
+                        	inOcean = true;
+                        } else {
+                        	biomeCanSpawnIn[islandIn] = true;
+                        }
                     }
 
                     int chance = (worldConfig.BiomeRarityScale + 1) - biomeConfig.biomeRarityWhenIsle;
-                    layerBiomeIsle.addIsle(biome, chance, biomeCanSpawnIn);
+                    layerBiomeIsle.addIsle(biome, chance, biomeCanSpawnIn, inOcean);
                 }
 
                 if (biomeConfig.biomeSizeWhenBorder == depth


### PR DESCRIPTION
Part 1/2.

inOcean should be applied for each Isle seperately, not once for the entire layer. It is also important to not set biomeCanSpawnIn[islandIn] = true; for isle biomes in the ocean. See part 2 for the rest.