### PR TITLE
Fix random biome generation with Virtual Biomes for a fixed seed

### DIFF
--- a/common/src/main/java/com/khorn/terraincontrol/configuration/ServerConfigProvider.java
+++ b/common/src/main/java/com/khorn/terraincontrol/configuration/ServerConfigProvider.java
@@ -246,9 +246,17 @@ public final class ServerConfigProvider implements ConfigProvider
     {
         StringBuilder loadedBiomeNames = new StringBuilder();
 
+        List<BiomeConfig> loadedBiomeList = new ArrayList<BiomeConfig>(loadedBiomes.values());
+        Collections.sort(loadedBiomeList, new Comparator<BiomeConfig>() {
+            @Override
+            public int compare(BiomeConfig a, BiomeConfig b) {
+                return getRequestedGenerationId(a) - getRequestedGenerationId(b);
+            }
+        });
+
         // Now that all settings are loaded, we can index them,
         // cross-reference between biomes, etc.
-        for (BiomeConfig biomeConfig : loadedBiomes.values())
+        for (BiomeConfig biomeConfig : loadedBiomeList)
         {
             // Statistics of the loaded biomes
             this.biomesCount++;


### PR DESCRIPTION
Fixes #444

We need to init array size because Mojang uses a strange custom ArrayList. RegistryID arrays are not correctly (but randomly!) copied when resized.
A better way to do it would be to add these biomes in a specific order.