### PR TITLE
Update Forge to 1.11 and fix virtual biome registration.

### DIFF
--- a/platforms/forge/build.gradle
+++ b/platforms/forge/build.gradle
@@ -6,7 +6,7 @@ buildscript
     {
         mavenCentral()
         mavenLocal()
-		jcenter()
+        jcenter()
         maven
         {
             url = "http://files.minecraftforge.net/maven"
@@ -27,10 +27,10 @@ apply plugin: 'net.minecraftforge.gradle.forge'
 // Project properties
 archivesBaseName = "terraincontrol-forge"
 description = "TerrainControl for Minecraft Forge"
-ext.forgeVersion = "1.10.2-12.18.1.2050"
+ext.forgeVersion = "1.11-13.19.1.2189"
 minecraft.version = ext.forgeVersion
 minecraft.runDir = "run"
-minecraft.mappings = "snapshot_20160708"
+minecraft.mappings = "snapshot_20161129"
 
 repositories
 {

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/ForgeEngine.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/ForgeEngine.java
@@ -1,6 +1,8 @@
 package com.khorn.terraincontrol.forge;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 import com.khorn.terraincontrol.LocalMaterialData;
 import com.khorn.terraincontrol.LocalWorld;
@@ -9,15 +11,45 @@ import com.khorn.terraincontrol.configuration.standard.PluginStandardValues;
 import com.khorn.terraincontrol.exception.InvalidConfigException;
 import com.khorn.terraincontrol.util.minecraftTypes.DefaultMaterial;
 
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.biome.Biome;
+import net.minecraftforge.fml.common.registry.IForgeRegistryEntry;
+
 public class ForgeEngine extends TerrainControlEngine
 {
 
     protected WorldLoader worldLoader;
+    protected Method ADD_OBJECT_RAW;
 
     public ForgeEngine(WorldLoader worldLoader)
     {
         super(new ForgeLogger());
         this.worldLoader = worldLoader;
+        // setup reflection method in order to properly register virtual biomes
+        try {
+            ADD_OBJECT_RAW = Biome.REGISTRY.getClass().getDeclaredMethod("addObjectRaw", int.class, ResourceLocation.class, IForgeRegistryEntry.class);
+            ADD_OBJECT_RAW.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        } catch (SecurityException e) {
+            e.printStackTrace();
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // Used to bypass Forge's API in order to properly register a virtual biome
+    // that would otherwise be blocked by Forge due to virtual biome ID's surpassing 255.
+    public void registerForgeBiome(int id, ResourceLocation resourceLocation, Biome biome) {
+        try {
+            this.ADD_OBJECT_RAW.invoke(Biome.REGISTRY, id, resourceLocation, biome);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+        } catch (InvocationTargetException e) {
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/TXCommandHandler.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/TXCommandHandler.java
@@ -28,19 +28,19 @@ final class TXCommandHandler implements ICommand
     }
 
     @Override
-    public String getCommandName()
+    public String getName()
     {
         return "tc";
     }
 
     @Override
-    public String getCommandUsage(ICommandSender var1)
+    public String getUsage(ICommandSender var1)
     {
         return "tc";
     }
 
     @Override
-    public List<String> getCommandAliases()
+    public List<String> getAliases()
     {
         return aliases;
     }
@@ -54,32 +54,32 @@ final class TXCommandHandler implements ICommand
         {
             if (argString == null || argString.length == 0)
             {
-                sender.addChatMessage(new TextComponentString("-- TerrainControl --"));
-                sender.addChatMessage(new TextComponentString("Commands:"));
-                sender.addChatMessage(new TextComponentString("/tc worldinfo - Show author and description information for this world."));
-                sender.addChatMessage(new TextComponentString("/tc biome - Show biome information for any biome at the player's coordinates."));
+                sender.sendMessage(new TextComponentString("-- TerrainControl --"));
+                sender.sendMessage(new TextComponentString("Commands:"));
+                sender.sendMessage(new TextComponentString("/tc worldinfo - Show author and description information for this world."));
+                sender.sendMessage(new TextComponentString("/tc biome - Show biome information for any biome at the player's coordinates."));
             } else if (argString[0].equals("worldinfo"))
             {
                 LocalWorld localWorld = worldLoader.getWorld(sender.getEntityWorld());
                 if (localWorld != null)
                 {
                     WorldConfig worldConfig = localWorld.getConfigs().getWorldConfig();
-                    sender.addChatMessage(new TextComponentString("-- World info --"));
-                    sender.addChatMessage(new TextComponentString("Author: " + worldConfig.author));
-                    sender.addChatMessage(new TextComponentString("Description: " + worldConfig.description));
+                    sender.sendMessage(new TextComponentString("-- World info --"));
+                    sender.sendMessage(new TextComponentString("Author: " + worldConfig.author));
+                    sender.sendMessage(new TextComponentString("Description: " + worldConfig.description));
                 } else
                 {
-                    sender.addChatMessage(new TextComponentString(PluginStandardValues.PLUGIN_NAME + " is not enabled for this world."));
+                    sender.sendMessage(new TextComponentString(PluginStandardValues.PLUGIN_NAME + " is not enabled for this world."));
                 }
             } else if (argString[0].equals("biome"))
             {
                 Biome biome = sender.getEntityWorld().getBiomeForCoordsBody(sender.getPosition());
-                sender.addChatMessage(new TextComponentString("-- Biome info --"));
-                sender.addChatMessage(new TextComponentString("Name: " + biome.getBiomeName()));
-                sender.addChatMessage(new TextComponentString("Id: " + Biome.getIdForBiome(biome)));
+                sender.sendMessage(new TextComponentString("-- Biome info --"));
+                sender.sendMessage(new TextComponentString("Name: " + biome.getBiomeName()));
+                sender.sendMessage(new TextComponentString("Id: " + Biome.getIdForBiome(biome)));
             } else
             {
-                sender.addChatMessage(new TextComponentString("Unknown command. Type /tc for a list of commands."));
+                sender.sendMessage(new TextComponentString("Unknown command. Type /tc for a list of commands."));
             }
         }
     }
@@ -87,7 +87,7 @@ final class TXCommandHandler implements ICommand
     @Override
     public boolean checkPermission(MinecraftServer server, ICommandSender sender)
     {
-        return sender.canCommandSenderUseCommand(2, this.getCommandName());
+        return sender.canUseCommand(2, this.getName());
     }
 
     @Override
@@ -99,11 +99,11 @@ final class TXCommandHandler implements ICommand
     @Override
     public int compareTo(ICommand that)
     {
-        return this.getCommandName().compareTo(that.getCommandName());
+        return this.getName().compareTo(that.getName());
     }
 
     @Override
-    public List<String> getTabCompletionOptions(MinecraftServer server, ICommandSender sender, String[] args, BlockPos pos)
+    public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, BlockPos pos)
     {
         return Collections.emptyList();
     }

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/TXWorldType.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/TXWorldType.java
@@ -45,8 +45,13 @@ public class TXWorldType extends WorldType
             return super.getBiomeProvider(mcWorld);
         }
 
-        // Load everything
-        ForgeWorld world = worldLoader.demandServerWorld((WorldServer) mcWorld);
+        ForgeWorld world = worldLoader.getWorld(mcWorld.getWorldInfo().getWorldName());
+        if (world == null) {
+            world = worldLoader.demandServerWorld((WorldServer) mcWorld);
+        } else
+        {
+            world.provideWorldInstance((WorldServer) mcWorld);
+        }
 
         Class<? extends BiomeGenerator> biomeGenClass = world.getConfigs().getWorldConfig().biomeMode;
         BiomeGenerator biomeGenerator = TerrainControl.getBiomeModeManager().createCached(biomeGenClass, world);

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/events/ClientNetworkHandler.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/events/ClientNetworkHandler.java
@@ -48,7 +48,7 @@ public class ClientNetworkHandler
             if (serverProtocolVersion == clientProtocolVersion)
             {
                 // Server sent config
-                WorldClient worldMC = FMLClientHandler.instance().getClient().theWorld;
+                WorldClient worldMC = FMLClientHandler.instance().getClient().world;
 
                 if (stream.readableBytes() > 4 && worldMC != null)
                 {
@@ -100,7 +100,7 @@ public class ClientNetworkHandler
         chatStyle.setColor(color);
         chat.setStyle(chatStyle);
 
-        Minecraft.getMinecraft().thePlayer.addChatMessage(chat);
+        Minecraft.getMinecraft().player.sendMessage(chat);
     }
 
     @SubscribeEvent

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/TXBiome.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/TXBiome.java
@@ -1,17 +1,19 @@
 package com.khorn.terraincontrol.forge.generator;
 
 import com.khorn.terraincontrol.BiomeIds;
+import com.khorn.terraincontrol.TerrainControl;
 import com.khorn.terraincontrol.configuration.BiomeConfig;
 import com.khorn.terraincontrol.configuration.WeightedMobSpawnGroup;
 import com.khorn.terraincontrol.configuration.standard.PluginStandardValues;
 import com.khorn.terraincontrol.configuration.standard.WorldStandardValues;
+import com.khorn.terraincontrol.forge.ForgeEngine;
 import com.khorn.terraincontrol.forge.util.MobSpawnGroupHelper;
+import com.khorn.terraincontrol.logging.LogMarker;
 import com.khorn.terraincontrol.util.helpers.StringHelper;
 import com.khorn.terraincontrol.util.minecraftTypes.DefaultBiome;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.registry.RegistryNamespaced;
 import net.minecraft.world.biome.Biome;
-import net.minecraftforge.fml.common.registry.GameRegistry;
+import net.minecraftforge.common.BiomeDictionary;
 
 import java.util.List;
 
@@ -64,21 +66,52 @@ public class TXBiome extends Biome
         ResourceLocation registryKey = new ResourceLocation(PluginStandardValues.PLUGIN_NAME.toLowerCase(), biomeNameForRegistry);
 
         // Check if registered earlier
-        @SuppressWarnings("unchecked")
-        RegistryNamespaced<ResourceLocation, Biome> registry = ((RegistryNamespaced<ResourceLocation, Biome>) GameRegistry.findRegistry(
-                Biome.class));
-        Biome alreadyRegisteredBiome = registry.getObject(registryKey);
+        Biome alreadyRegisteredBiome = Biome.REGISTRY.getObject(registryKey);
         if (alreadyRegisteredBiome != null)
         {
             return alreadyRegisteredBiome;
         }
 
         // No existing biome, create new one
-        TXBiome biome = new TXBiome(biomeConfig, registryKey, biomeIds);
-        if (!biomeIds.isVirtual()) {
-            registry.register(biomeIds.getGenerationId(), biome.getRegistryName(), biome);
+        TXBiome customBiome = new TXBiome(biomeConfig, registryKey, biomeIds);
+        int savedBiomeId = biomeIds.getSavedId();
+
+        if (biomeIds.isVirtual())
+        {
+            // Virtual biomes hack: register, then let original biome overwrite
+            // In this way, the id --> biome mapping returns the original biome,
+            // and the biome --> id mapping returns savedBiomeId for both the
+            // original and custom biome
+            Biome existingBiome = Biome.getBiome(savedBiomeId);
+
+            if (existingBiome == null)
+            {
+                // Original biome not yet registered. This is because it's a
+                // custom biome that is loaded after this virtual biome, so it
+                // will soon be registered
+                Biome.REGISTRY.register(biomeIds.getGenerationId(), registryKey, customBiome);
+                TerrainControl.log(LogMarker.DEBUG, ",{},{},{}", biomeConfig.getName(), savedBiomeId, biomeIds.getGenerationId());
+            } else
+            {
+                ResourceLocation existingBiomeKey = Biome.REGISTRY.getNameForObject(existingBiome);
+                ForgeEngine forgeEngine = ((ForgeEngine) TerrainControl.getEngine());
+                forgeEngine.registerForgeBiome(biomeIds.getSavedId(), registryKey, customBiome);
+                forgeEngine.registerForgeBiome(biomeIds.getSavedId(), existingBiomeKey, existingBiome);
+                TerrainControl.log(LogMarker.DEBUG, ",{},{},{}", biomeConfig.getName(), savedBiomeId, biomeIds.getGenerationId());
+            }
+        } else
+        {
+            // Normal insertion
+            Biome.REGISTRY.register(savedBiomeId, registryKey, customBiome);
+            TerrainControl.log(LogMarker.DEBUG, ",{},{},{}", biomeConfig.getName(), savedBiomeId, biomeIds.getGenerationId());
         }
-        return biome;
+
+        if (!BiomeDictionary.hasAnyType(customBiome)) {
+            // register custom biome with Forge's BiomeDictionary
+            BiomeDictionary.makeBestGuess(customBiome);
+        }
+
+        return customBiome;
     }
 
     private int skyColor;

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/TXChunkGenerator.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/TXChunkGenerator.java
@@ -118,12 +118,12 @@ public class TXChunkGenerator implements IChunkGenerator
     }
 
     @Override
-    public BlockPos getStrongholdGen(World worldIn, String structureName, BlockPos blockPos)
+    public BlockPos getStrongholdGen(World worldIn, String structureName, BlockPos position, boolean flag)
     {
         // Gets the nearest stronghold
         if (("Stronghold".equals(structureName)) && (this.world.strongholdGen != null))
         {
-            return this.world.strongholdGen.getClosestStrongholdPos(worldIn, blockPos);
+            return this.world.strongholdGen.getClosestStrongholdPos(worldIn, position, flag);
         }
         return null;
     }
@@ -160,17 +160,7 @@ public class TXChunkGenerator implements IChunkGenerator
     }
 
     @Override
-    public boolean generateStructures(Chunk chunkIn, int x, int z)
-    {
-        // retroGen -> generated ocean monument in existing chunks in vanilla
-        // Disabled, as
-        // * it's not enabled in the Bukkit version, as Spigot's
-        // generator API doesn't support it
-        // * people updating to 1.8 might be surprised why this monument
-        // spawns in existing chunks of their customized ocean biome
-        // * changing the spawn settings of ocean monuments makes them spawn
-        // at different positions, so extra monuments will be spawned in old
-        // chunks
+    public boolean generateStructures(Chunk chunkIn, int x, int z) {
         return false;
     }
 

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/structure/TXMineshaftGen.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/structure/TXMineshaftGen.java
@@ -8,6 +8,8 @@ import com.khorn.terraincontrol.forge.util.WorldHelper;
 import com.khorn.terraincontrol.util.ChunkCoordinate;
 import com.khorn.terraincontrol.util.minecraftTypes.StructureNames;
 
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import net.minecraft.world.gen.structure.MapGenMineshaft;
 import net.minecraft.world.gen.structure.MapGenStructure;
 import net.minecraft.world.gen.structure.StructureMineshaftStart;
@@ -20,7 +22,7 @@ public class TXMineshaftGen extends MapGenStructure
     {
         if (rand.nextInt(80) < Math.max(Math.abs(chunkX), Math.abs(chunkZ)))
         {
-            LocalWorld world = WorldHelper.toLocalWorld(this.worldObj);
+            LocalWorld world = WorldHelper.toLocalWorld(this.world);
             LocalBiome biome = world.getBiome(chunkX * 16 + 8, chunkZ * 16 + 8);
             BiomeConfig biomeConfig = biome.getBiomeConfig();
             if (biomeConfig.mineshaftType == MineshaftType.disabled)
@@ -39,7 +41,7 @@ public class TXMineshaftGen extends MapGenStructure
     @Override
     protected StructureStart getStructureStart(int chunkX, int chunkZ)
     {
-        LocalWorld world = WorldHelper.toLocalWorld(this.worldObj);
+        LocalWorld world = WorldHelper.toLocalWorld(this.world);
         LocalBiome biome = world.getBiome(chunkX * ChunkCoordinate.CHUNK_X_SIZE + 8,
                 chunkZ * ChunkCoordinate.CHUNK_Z_SIZE + 8);
         BiomeConfig biomeConfig = biome.getBiomeConfig();
@@ -49,12 +51,48 @@ public class TXMineshaftGen extends MapGenStructure
             mineshaftType = MapGenMineshaft.Type.MESA;
         }
 
-        return new StructureMineshaftStart(this.worldObj, this.rand, chunkX, chunkZ, mineshaftType);
+        return new StructureMineshaftStart(this.world, this.rand, chunkX, chunkZ, mineshaftType);
     }
 
     @Override
     public String getStructureName()
     {
         return StructureNames.MINESHAFT;
+    }
+
+    @Override
+    public BlockPos getClosestStrongholdPos(World worldIn, BlockPos pos, boolean p_180706_3_)
+    {
+        // int i = 1000;
+        int j = pos.getX() >> 4;
+        int k = pos.getZ() >> 4;
+
+        for (int l = 0; l <= 1000; ++l)
+        {
+            for (int i1 = -l; i1 <= l; ++i1)
+            {
+                boolean flag = i1 == -l || i1 == l;
+
+                for (int j1 = -l; j1 <= l; ++j1)
+                {
+                    boolean flag1 = j1 == -l || j1 == l;
+
+                    if (flag || flag1)
+                    {
+                        int k1 = j + i1;
+                        int l1 = k + j1;
+                        this.rand.setSeed((long)(k1 ^ l1) ^ worldIn.getSeed());
+                        this.rand.nextInt();
+
+                        if (this.canSpawnStructureAtCoords(k1, l1) && (!p_180706_3_ || !worldIn.isChunkGeneratedAt(k1, l1)))
+                        {
+                            return new BlockPos((k1 << 4) + 8, 64, (l1 << 4) + 8);
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/structure/TXNetherFortressGen.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/structure/TXNetherFortressGen.java
@@ -8,6 +8,9 @@ import net.minecraft.entity.monster.EntityBlaze;
 import net.minecraft.entity.monster.EntityMagmaCube;
 import net.minecraft.entity.monster.EntityPigZombie;
 import net.minecraft.entity.monster.EntitySkeleton;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome.SpawnListEntry;
 import net.minecraft.world.gen.structure.MapGenNetherBridge;
 import net.minecraft.world.gen.structure.MapGenStructure;
@@ -28,8 +31,7 @@ public class TXNetherFortressGen extends MapGenStructure
         this.spawnList.add(new SpawnListEntry(EntityMagmaCube.class, 3, 4, 4));
     }
 
-    @SuppressWarnings({"rawtypes", "UnusedDeclaration"})
-    public List getSpawnList()
+    public List<SpawnListEntry> getSpawnList()
     {
         return this.spawnList;
     }
@@ -39,20 +41,20 @@ public class TXNetherFortressGen extends MapGenStructure
     {
         int var3 = chunkX >> 4;
         int var4 = chunkZ >> 4;
-        rand.setSeed((long) (var3 ^ var4 << 4) ^ worldObj.getSeed());
-        rand.nextInt();
+        this.rand.setSeed((long) (var3 ^ var4 << 4) ^ this.world.getSeed());
+        this.rand.nextInt();
 
-        if (rand.nextInt(3) != 0)
+        if (this.rand.nextInt(3) != 0)
         {
             return false;
         } else
         {
-            if (chunkX != (var3 << 4) + 4 + rand.nextInt(8))
+            if (chunkX != (var3 << 4) + 4 + this.rand.nextInt(8))
             {
                 return false;
             } else
             {
-                LocalWorld world = WorldHelper.toLocalWorld(worldObj);
+                LocalWorld world = WorldHelper.toLocalWorld(this.world);
                 LocalBiome biome = world.getBiome(chunkX * 16 + 8, chunkZ * 16 + 8);
                 if (!biome.getBiomeConfig().netherFortressesEnabled)
                 {
@@ -66,12 +68,46 @@ public class TXNetherFortressGen extends MapGenStructure
     @Override
     protected StructureStart getStructureStart(int chunkX, int chunkZ)
     {
-        return new MapGenNetherBridge.Start(this.worldObj, this.rand, chunkX, chunkZ);
+        return new MapGenNetherBridge.Start(this.world, this.rand, chunkX, chunkZ);
     }
 
     @Override
     public String getStructureName()
     {
         return StructureNames.NETHER_FORTRESS;
+    }
+
+    @Override
+    public BlockPos getClosestStrongholdPos(World worldIn, BlockPos pos, boolean p_180706_3_)
+    {
+        // int i = 1000;
+        int j = pos.getX() >> 4;
+        int k = pos.getZ() >> 4;
+
+        for (int l = 0; l <= 1000; ++l)
+        {
+            for (int i1 = -l; i1 <= l; ++i1)
+            {
+                boolean flag = i1 == -l || i1 == l;
+
+                for (int j1 = -l; j1 <= l; ++j1)
+                {
+                    boolean flag1 = j1 == -l || j1 == l;
+
+                    if (flag || flag1)
+                    {
+                        int k1 = j + i1;
+                        int l1 = k + j1;
+
+                        if (this.canSpawnStructureAtCoords(k1, l1) && (!p_180706_3_ || !worldIn.isChunkGeneratedAt(k1, l1)))
+                        {
+                            return new BlockPos((k1 << 4) + 8, 64, (l1 << 4) + 8);
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/structure/TXOceanMonumentGen.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/structure/TXOceanMonumentGen.java
@@ -13,6 +13,7 @@ import com.khorn.terraincontrol.util.minecraftTypes.StructureNames;
 import net.minecraft.entity.monster.EntityGuardian;
 import net.minecraft.init.Biomes;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.Biome.SpawnListEntry;
 import net.minecraft.world.biome.BiomeProvider;
@@ -63,7 +64,7 @@ public class TXOceanMonumentGen extends MapGenStructure
 
         int i1 = p_75047_1_ / this.gridSize;
         int j1 = p_75047_2_ / this.gridSize;
-        Random random = this.worldObj.setRandomSeed(i1, j1, 10387313);
+        Random random = this.world.setRandomSeed(i1, j1, 10387313);
         i1 *= this.gridSize;
         j1 *= this.gridSize;
         i1 += (random.nextInt(this.randomOffset + 1) + random.nextInt(this.randomOffset + 1)) / 2;
@@ -71,13 +72,13 @@ public class TXOceanMonumentGen extends MapGenStructure
 
         if (k == i1 && l == j1)
         {
-            BiomeProvider biomeProvider = this.worldObj.getBiomeProvider();
+            BiomeProvider biomeProvider = this.world.getBiomeProvider();
             if (biomeProvider.getBiome(new BlockPos(k * 16 + 8, 64, l * 16 + 8), (Biome) null) != Biomes.DEEP_OCEAN)
             {
                 return false;
             }
 
-            boolean flag = this.worldObj.getBiomeProvider().areBiomesViable(k * 16 + 8, l * 16 + 8, 29, monumentSpawnBiomes);
+            boolean flag = this.world.getBiomeProvider().areBiomesViable(k * 16 + 8, l * 16 + 8, 29, monumentSpawnBiomes);
 
             if (flag)
             {
@@ -97,7 +98,7 @@ public class TXOceanMonumentGen extends MapGenStructure
     @Override
     protected StructureStart getStructureStart(int p_75049_1_, int p_75049_2_)
     {
-        return new StructureOceanMonument.StartMonument(this.worldObj, this.rand, p_75049_1_, p_75049_2_);
+        return new StructureOceanMonument.StartMonument(this.world, this.rand, p_75049_1_, p_75049_2_);
     }
 
     public List<SpawnListEntry> getMonsterSpawnList()
@@ -105,4 +106,9 @@ public class TXOceanMonumentGen extends MapGenStructure
         return this.mobList;
     }
 
+    public BlockPos getClosestStrongholdPos(World worldIn, BlockPos pos, boolean p_180706_3_)
+    {
+        this.world = worldIn;
+        return findNearestStructurePosBySpacing(worldIn, this, pos, this.gridSize, this.gridSize - this.randomOffset - 1, 10387313, true, 100, p_180706_3_);
+    }
 }

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/structure/TXRareBuildingGen.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/structure/TXRareBuildingGen.java
@@ -13,6 +13,7 @@ import com.khorn.terraincontrol.util.minecraftTypes.StructureNames;
 
 import net.minecraft.entity.monster.EntityWitch;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.Biome.SpawnListEntry;
 import net.minecraft.world.gen.structure.*;
@@ -76,7 +77,7 @@ public class TXRareBuildingGen extends MapGenStructure
 
         int var5 = chunkX / this.maxDistanceBetweenScatteredFeatures;
         int var6 = chunkZ / this.maxDistanceBetweenScatteredFeatures;
-        Random random = this.worldObj.setRandomSeed(var5, var6, 14357617);
+        Random random = this.world.setRandomSeed(var5, var6, 14357617);
         var5 *= this.maxDistanceBetweenScatteredFeatures;
         var6 *= this.maxDistanceBetweenScatteredFeatures;
         var5 += random.nextInt(this.maxDistanceBetweenScatteredFeatures - this.minDistanceBetweenScatteredFeatures);
@@ -84,7 +85,7 @@ public class TXRareBuildingGen extends MapGenStructure
 
         if (var3 == var5 && var4 == var6)
         {
-            Biome biomeAtPosition = this.worldObj.getBiomeProvider().getBiome(
+            Biome biomeAtPosition = this.world.getBiomeProvider().getBiome(
                     new BlockPos(var3 * 16 + 8, 0, var4 * 16 + 8));
 
             if (biomeList.contains(biomeAtPosition))
@@ -99,7 +100,7 @@ public class TXRareBuildingGen extends MapGenStructure
     @Override
     protected StructureStart getStructureStart(int chunkX, int chunkZ)
     {
-        return new TXRareBuildingStart(this.worldObj, this.rand, chunkX, chunkZ);
+        return new TXRareBuildingStart(this.world, this.rand, chunkX, chunkZ);
     }
 
     /**
@@ -130,5 +131,12 @@ public class TXRareBuildingGen extends MapGenStructure
     public String getStructureName()
     {
         return StructureNames.RARE_BUILDING;
+    }
+
+    @Override
+    public BlockPos getClosestStrongholdPos(World worldIn, BlockPos pos, boolean p_180706_3_)
+    {
+        this.world = worldIn;
+        return findNearestStructurePosBySpacing(worldIn, this, pos, this.maxDistanceBetweenScatteredFeatures, 8, 14357617, false, 100, p_180706_3_);
     }
 }

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/structure/TXStrongholdGen.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/structure/TXStrongholdGen.java
@@ -1,37 +1,26 @@
 package com.khorn.terraincontrol.forge.generator.structure;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 
+import com.google.common.collect.ImmutableMap;
 import com.khorn.terraincontrol.LocalBiome;
 import com.khorn.terraincontrol.configuration.ServerConfigProvider;
 import com.khorn.terraincontrol.forge.ForgeBiome;
-import com.khorn.terraincontrol.util.minecraftTypes.StructureNames;
 
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.gen.structure.MapGenStronghold;
-import net.minecraft.world.gen.structure.MapGenStructure;
-import net.minecraft.world.gen.structure.StructureStart;
-import net.minecraft.world.gen.structure.StructureStrongholdPieces;
 
-public class TXStrongholdGen extends MapGenStructure
+public class TXStrongholdGen extends MapGenStronghold
 {
     private List<Biome> allowedBiomes;
 
-    private boolean ranBiomeCheck;
-    private ChunkPos[] structureCoords;
-    private double distance;
-    private int spread;
-
     public TXStrongholdGen(ServerConfigProvider configs)
     {
-        this.distance = configs.getWorldConfig().strongholdDistance;
-        this.structureCoords = new ChunkPos[configs.getWorldConfig().strongholdCount];
-        this.spread = configs.getWorldConfig().strongholdSpread;
+        super(ImmutableMap.of(
+                "distance", String.valueOf(configs.getWorldConfig().strongholdDistance),
+                "count", String.valueOf(configs.getWorldConfig().strongholdCount),
+                "spread",  String.valueOf(configs.getWorldConfig().strongholdSpread)));
 
         allowedBiomes = new ArrayList<Biome>();
 
@@ -44,97 +33,5 @@ public class TXStrongholdGen extends MapGenStructure
                 allowedBiomes.add(((ForgeBiome) biome).getHandle());
             }
         }
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    @Override
-    protected boolean canSpawnStructureAtCoords(int par1, int par2)
-    {
-        if (!this.ranBiomeCheck)
-        {
-            Random random = new Random();
-            random.setSeed(this.worldObj.getSeed());
-            double randomNumBetween0and2PI = random.nextDouble() * Math.PI * 2.0D;
-            int var6 = 1;
-
-            for (int i = 0; i < this.structureCoords.length; ++i)
-            {
-                double var8 = (1.25D * var6 + random.nextDouble()) * this.distance * var6;
-                int var10 = (int) Math.round(Math.cos(randomNumBetween0and2PI) * var8);
-                int var11 = (int) Math.round(Math.sin(randomNumBetween0and2PI) * var8);
-                ArrayList var12 = new ArrayList();
-                Collections.addAll(var12, this.allowedBiomes);
-                BlockPos var13 = this.worldObj.getBiomeProvider().findBiomePosition((var10 << 4) + 8, (var11 << 4) + 8, 112, var12,
-                        random);
-
-                if (var13 != null)
-                {
-                    var10 = var13.getX() >> 4;
-                    var11 = var13.getZ() >> 4;
-                }
-
-                this.structureCoords[i] = new ChunkPos(var10, var11);
-                randomNumBetween0and2PI += (Math.PI * 2D) * var6 / this.spread;
-
-                if (i == this.spread)
-                {
-                    var6 += 2 + random.nextInt(5);
-                    this.spread += 1 + random.nextInt(2);
-                }
-            }
-
-            this.ranBiomeCheck = true;
-        }
-
-        ChunkPos[] structureCoordsLocal = this.structureCoords;
-
-        for (ChunkPos structureCoord : structureCoordsLocal)
-        {
-            if (par1 == structureCoord.chunkXPos && par2 == structureCoord.chunkZPos)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Returns a list of other locations at which the structure generation has
-     * been run, or null if not relevant to this structure generator.
-     */
-    @Override
-    protected List<BlockPos> getCoordList()
-    {
-        List<BlockPos> chunkPositions = new ArrayList<BlockPos>();
-
-        for (ChunkPos structureCoord : structureCoords)
-        {
-            if (structureCoord != null)
-            {
-                chunkPositions.add(structureCoord.getCenterBlock(64));
-            }
-        }
-
-        return chunkPositions;
-    }
-
-    @Override
-    protected StructureStart getStructureStart(int par1, int par2)
-    {
-        MapGenStronghold.Start start = new MapGenStronghold.Start(this.worldObj, this.rand, par1, par2);
-
-        while (start.getComponents().isEmpty() || ((StructureStrongholdPieces.Stairs2) start.getComponents().get(0)).strongholdPortalRoom == null)
-        {
-            start = new MapGenStronghold.Start(this.worldObj, this.rand, par1, par2);
-        }
-
-        return start;
-    }
-
-    @Override
-    public String getStructureName()
-    {
-        return StructureNames.STRONGHOLD;
     }
 }

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/structure/TXVillageGen.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/structure/TXVillageGen.java
@@ -5,6 +5,9 @@ import com.khorn.terraincontrol.configuration.BiomeConfig.VillageType;
 import com.khorn.terraincontrol.configuration.ServerConfigProvider;
 import com.khorn.terraincontrol.forge.ForgeBiome;
 import com.khorn.terraincontrol.util.minecraftTypes.StructureNames;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.gen.structure.MapGenStructure;
 import net.minecraft.world.gen.structure.StructureStart;
@@ -64,7 +67,7 @@ public class TXVillageGen extends MapGenStructure
 
         int var5 = chunkX / this.distance;
         int var6 = chunkZ / this.distance;
-        Random var7 = this.worldObj.setRandomSeed(var5, var6, 10387312);
+        Random var7 = this.world.setRandomSeed(var5, var6, 10387312);
         var5 *= this.distance;
         var6 *= this.distance;
         var5 += var7.nextInt(this.distance - this.minimumDistance);
@@ -72,7 +75,7 @@ public class TXVillageGen extends MapGenStructure
 
         if (var3 == var5 && var4 == var6)
         {
-            boolean canSpawn = this.worldObj.getBiomeProvider().areBiomesViable(var3 * 16 + 8, var4 * 16 + 8, 0, villageSpawnBiomes);
+            boolean canSpawn = this.world.getBiomeProvider().areBiomesViable(var3 * 16 + 8, var4 * 16 + 8, 0, villageSpawnBiomes);
 
             if (canSpawn)
             {
@@ -86,12 +89,19 @@ public class TXVillageGen extends MapGenStructure
     @Override
     protected StructureStart getStructureStart(int chunkX, int chunkZ)
     {
-        return new TXVillageStart(this.worldObj, this.rand, chunkX, chunkZ, this.size);
+        return new TXVillageStart(this.world, this.rand, chunkX, chunkZ, this.size);
     }
 
     @Override
     public String getStructureName()
     {
         return StructureNames.VILLAGE;
+    }
+
+    @Override
+    public BlockPos getClosestStrongholdPos(World worldIn, BlockPos pos, boolean p_180706_3_)
+    {
+        this.world = worldIn;
+        return findNearestStructurePosBySpacing(worldIn, this, pos, this.distance, 8, 10387312, false, 100, p_180706_3_);
     }
 }

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/util/MobSpawnGroupHelper.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/util/MobSpawnGroupHelper.java
@@ -8,8 +8,11 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EnumCreatureType;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.Biome.SpawnListEntry;
+import net.minecraftforge.fml.common.registry.EntityEntry;
+import net.minecraftforge.fml.common.registry.EntityRegistry;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -115,8 +118,8 @@ public final class MobSpawnGroupHelper
      */
     static Class<? extends EntityLiving> toMinecraftClass(String mobName)
     {
-        Class<? extends Entity> clazz = EntityList.NAME_TO_CLASS.get(mobName);
-        if (EntityLiving.class.isAssignableFrom(clazz))
+        Class<? extends Entity> clazz = EntityList.getClass(new ResourceLocation(mobName));
+        if (clazz != null && EntityLiving.class.isAssignableFrom(clazz))
         {
             return clazz.asSubclass(EntityLiving.class);
         }
@@ -128,8 +131,13 @@ public final class MobSpawnGroupHelper
      * @param entityClass The entity class.
      * @return The entity name, or null if not found.
      */
-    private static String fromMinecraftClass(Class<?> entityClass)
+    private static String fromMinecraftClass(Class<? extends Entity> entityClass)
     {
-        return EntityList.CLASS_TO_NAME.get(entityClass);
+        EntityEntry entry = EntityRegistry.getEntry(entityClass);
+        if (entry != null) {
+            return entry.getName();
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
This PR addresses tickets #442, #458, #475 by fixing virtual biome registration with Forge. I also updated Forge to 1.11 so it supports latest master.

There were 2 issues with the current code

- Forge blocking any biome registration with an ID > 255. Forge essentially creates a wrapper around the Biome registry in order to enforce rules such as ensuring the biome ID being registered doesn't surpass 255. While this is fine for the most part, it breaks support for virtual biomes which TerrainControl adds. To workaround the issue, I simply use reflection to bypass Forge's API and register the virtual biomes directly into the biome registry.
- WorldProvider init would cause TC to register the same world twice due to a bug in TCWorldType. I simply check to see if the world has been registered and if so setup the provider instance otherwise I run through normal TC loading logic.

For those on 1.10.2, you can find my virtual biome fix here

https://github.com/bloodmc/TerrainControl/tree/1.10.2