### PR TITLE
[WIP] Fix worldserver instance not always being set in ForgeWorld.

### DIFF
--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/TXWorldType.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/TXWorldType.java
@@ -48,10 +48,8 @@ public class TXWorldType extends WorldType
         ForgeWorld world = worldLoader.getWorld(mcWorld.getWorldInfo().getWorldName());
         if (world == null) {
             world = worldLoader.demandServerWorld((WorldServer) mcWorld);
-        } else
-        {
-            world.provideWorldInstance((WorldServer) mcWorld);
         }
+        world.provideWorldInstance((WorldServer) mcWorld);
 
         Class<? extends BiomeGenerator> biomeGenClass = world.getConfigs().getWorldConfig().biomeMode;
         BiomeGenerator biomeGenerator = TerrainControl.getBiomeModeManager().createCached(biomeGenClass, world);


### PR DESCRIPTION
This fixes a bug with my last commit where the ForgeWorld wouldn't always have a proper WorldServer instance set.

Still working on this.