### PR TITLE
Fix map item texture

### DIFF
--- a/platforms/bukkit/src/main/java/com/khorn/terraincontrol/bukkit/generator/TXWorldProvider.java
+++ b/platforms/bukkit/src/main/java/com/khorn/terraincontrol/bukkit/generator/TXWorldProvider.java
@@ -20,8 +20,9 @@ public class TXWorldProvider extends WorldProviderNormal
         this.localWorld = localWorld;
         this.oldWorldProvider = oldWorldProvider;
         this.a(localWorld.getWorld());
-        this.d = oldWorldProvider.l();
-        this.e = oldWorldProvider.m();
+        this.d = oldWorldProvider.l(); // doesWaterVaporize
+        this.f = oldWorldProvider.m(); // hasSkyLight
+        this.e = oldWorldProvider.n(); // hasNoSky (see https://github.com/ModCoderPack/MCPBot-Issues/issues/330)
     }
 
     @Override


### PR DESCRIPTION
Fixes #492 and also fixes #519 (which is a duplicate...)

This was caused by the splitting of two fields in a recent update.  See ModCoderPack/MCPBot-Issues#330 for more information about these fields.  Because NMS is being used (ಠ_ಠ), this change was missed (which is to be expected for NMS).

-----

Alright, I'm just going to make a complaint (that can be ignored).  Plugins shouldn't be using NMS.  Yes, it's the same code as exposed via MCP in forge, but the mappings used by NMS aren't designed for other developers, and thus changes like this can easily be missed.  Bukkit does have its own generation API, although it's a bit lackluster.  In the future, to avoid mistakes like this, take a look at the diff of the relevant classes in MCP whenever there's an NMS version bump (if you've got forge, you've got MCP).  That said, everyone makes this kind of mistake (md_5 made it when updating craftbukkit itself, because an obfuscated sound field was included in the diff and keeping it in the diff meant the wrong sound was used), so don't feel too bad.