### PR TITLE
Fix crashes after dimension change (forge)

### DIFF
--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/events/WorldListener.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/events/WorldListener.java
@@ -1,9 +1,10 @@
 package com.khorn.terraincontrol.forge.events;
 
+import com.khorn.terraincontrol.TerrainControl;
 import com.khorn.terraincontrol.forge.ForgeWorld;
 import com.khorn.terraincontrol.forge.WorldLoader;
 import com.khorn.terraincontrol.forge.util.WorldHelper;
-
+import com.khorn.terraincontrol.logging.LogMarker;
 import net.minecraft.world.World;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -28,6 +29,7 @@ public class WorldListener
             return;
         }
 
-        this.worldLoader.unloadWorld(forgeWorld);
+        //this.worldLoader.unloadWorld(forgeWorld);
+        TerrainControl.log(LogMarker.INFO, "Why would we need to unload world \"{}\"?", forgeWorld.getName());
     }
 }


### PR DESCRIPTION
> Fixes #497 and #499
> 
> World configuration is sometimes unloaded on dimension change.
> I do not understand why we need to unload world configuration on world change. It could cause chunk glitches when quit/reload (without closing MC) a solo game.
> 
> It may fix #516 too (not sure).

This change has to be modified (remove listener or replace comment by some conditions) but I need explanations to understand why we need to unload TC configuration on some cases (the log I added do not help me to understand why).