### PR TITLE
Enable BO3 trees to be generated at different heights

### DIFF
--- a/common/src/main/java/com/khorn/terraincontrol/customobjects/bo3/BO3.java
+++ b/common/src/main/java/com/khorn/terraincontrol/customobjects/bo3/BO3.java
@@ -78,7 +78,7 @@ public class BO3 implements CustomObject
         {
             variance = random.nextInt(variance + 1);
         }
-        return MathHelper.clamp(offset + variance, TerrainControl.WORLD_DEPTH, TerrainControl.WORLD_HEIGHT);
+        return offset + variance;
     }
 
     @Override
@@ -194,7 +194,7 @@ public class BO3 implements CustomObject
         return true;
     }
 
-    protected boolean spawn(LocalWorld world, Random random, int x, int z)
+    public boolean spawn(LocalWorld world, Random random, int x, int z)
     {
         Rotation rotation = settings.rotateRandomly ? Rotation.getRandomRotation(random) : Rotation.NORTH;
         int y = 0;
@@ -216,6 +216,7 @@ public class BO3 implements CustomObject
         }
         // Offset by static and random settings values
         y += this.getOffsetAndVariance(random, settings.spawnHeightOffset, settings.spawnHeightVariance);
+        y =  MathHelper.clamp(y, TerrainControl.WORLD_DEPTH, TerrainControl.WORLD_HEIGHT);
         if (!canSpawnAt(world, rotation, x, y, z))
         {
             return false;

--- a/common/src/main/java/com/khorn/terraincontrol/generator/resource/SaplingGen.java
+++ b/common/src/main/java/com/khorn/terraincontrol/generator/resource/SaplingGen.java
@@ -4,6 +4,7 @@ import com.khorn.terraincontrol.LocalWorld;
 import com.khorn.terraincontrol.configuration.BiomeConfig;
 import com.khorn.terraincontrol.configuration.ConfigFunction;
 import com.khorn.terraincontrol.customobjects.CustomObject;
+import com.khorn.terraincontrol.customobjects.bo3.BO3;
 import com.khorn.terraincontrol.exception.InvalidConfigException;
 import com.khorn.terraincontrol.util.Rotation;
 
@@ -147,12 +148,23 @@ public class SaplingGen extends ConfigFunction<BiomeConfig>
                     spawnZ += offset[1];
                 }
 
-                if (tree.spawnForced(world, random, rotation, spawnX, y, spawnZ))
+                if(tree instanceof BO3)
                 {
-                    // Success!
-                    return true;
+                    if(((BO3) tree).spawn(world, random, spawnX, spawnZ))
+                    {
+                        // Success!
+                        return true;
+                    }
                 }
-            }
+                else
+                {
+                    if (tree.spawnForced(world, random, rotation, spawnX, y, spawnZ))
+                    {
+                        // Success!
+                        return true;
+                    }
+                }
+              }
         }
         return false;
     }

--- a/common/src/main/java/com/khorn/terraincontrol/generator/resource/TreeGen.java
+++ b/common/src/main/java/com/khorn/terraincontrol/generator/resource/TreeGen.java
@@ -5,6 +5,7 @@ import com.khorn.terraincontrol.TerrainControl;
 import com.khorn.terraincontrol.configuration.BiomeConfig;
 import com.khorn.terraincontrol.configuration.ConfigFunction;
 import com.khorn.terraincontrol.customobjects.CustomObject;
+import com.khorn.terraincontrol.customobjects.bo3.BO3;
 import com.khorn.terraincontrol.exception.InvalidConfigException;
 import com.khorn.terraincontrol.logging.LogMarker;
 import com.khorn.terraincontrol.util.ChunkCoordinate;
@@ -143,20 +144,32 @@ public class TreeGen extends Resource
 
             int x = chunkCoord.getBlockXCenter() + random.nextInt(ChunkCoordinate.CHUNK_X_SIZE);
             int z = chunkCoord.getBlockZCenter() + random.nextInt(ChunkCoordinate.CHUNK_Z_SIZE);
-            int y = world.getHighestBlockYAt(x, z);
             CustomObject tree = trees.get(treeKind);
-            Rotation rotation = Rotation.getRandomRotation(random);
 
-            if (!tree.canSpawnAt(world, rotation, x, y, z))
+            if(tree instanceof BO3)
             {
-                // Try another tree
-                continue;
+                if(((BO3) tree).spawn(world, random, x, z))
+                {
+                    // Success!
+                    return;
+                }
             }
-
-            if (tree.spawnForced(world, random, rotation, x, y, z))
+            else
             {
-                // Success!
-                return;
+                int y = world.getHighestBlockYAt(x, z);
+                Rotation rotation = Rotation.getRandomRotation(random);
+
+                if (!tree.canSpawnAt(world, rotation, x, y, z))
+                {
+                    // Try another tree
+                    continue;
+                }
+
+                if (tree.spawnForced(world, random, rotation, x, y, z))
+                {
+                    // Success!
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
This enable to generate trees at different heights when SpawnHeightOffset and SpawnHeightVariance in BO3.