### PR TITLE
Fix field name reflection.

### DIFF
--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/util/NBTHelper.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/util/NBTHelper.java
@@ -32,7 +32,7 @@ public class NBTHelper
         Map<String, NBTBase> nmsChildTags = null;
         try
         {
-            mapField = NBTTagCompound.class.getDeclaredField("map");
+            mapField = NBTTagCompound.class.getDeclaredField("field_74784_a"); //tagMap
             mapField.setAccessible(true);
             nmsChildTags = (Map<String, NBTBase>) mapField.get(nmsTag);
         } catch (Exception e)


### PR DESCRIPTION
Fixes thread dump when trying to get declared field by non-obfuscated name.

Signed-off-by: Dockter <dockter@almuramc.com>